### PR TITLE
Add SPDX license identifiers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+SPDX-License-Identifier: MIT
+
 MIT License
 
 Copyright (c) 2025 bniladridas

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright 2025 bniladridas. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 
 import 'package:window_manager/window_manager.dart';

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -38,11 +38,13 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_macos_build_settings(target)
-    # Suppress warnings from third-party flutter_inappwebview_macos package
+    # Suppress warnings only for flutter_inappwebview_macos pod
     # These are harmless deprecation and unused variable warnings
-    target.build_configurations.each do |config|
-      config.build_settings['GCC_WARN_INHIBIT_ALL_WARNINGS'] = 'YES'
-      config.build_settings['SWIFT_SUPPRESS_WARNINGS'] = 'YES'
+    if target.name == 'flutter_inappwebview_macos'
+      target.build_configurations.each do |config|
+        config.build_settings['GCC_WARN_INHIBIT_ALL_WARNINGS'] = 'YES'
+        config.build_settings['SWIFT_SUPPRESS_WARNINGS'] = 'YES'
+      end
     end
   end
 end


### PR DESCRIPTION
Adds SPDX-License-Identifier: MIT to LICENSE and lib/main.dart for better license compliance and machine-readability. Also fixes broad warning suppression from PR #4 by scoping to only flutter_inappwebview_macos pod.