### PR TITLE
Add note in CI log for integration_test plugin warning

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -24,5 +24,6 @@ jobs:
     - run: flutter pub get
     - run: flutter analyze
     - run: flutter test
+    - run: "echo 'Note: The integration_test plugin warning is expected since tests are in e2e/ instead of integration_test/.'"
     - run: flutter test e2e/
     - run: flutter build macos


### PR DESCRIPTION
This PR adds a note in the CI log explaining the expected 'integration_test plugin was not detected' warning, since tests are kept in the e2e/ directory instead of integration_test/.