### PR TITLE
Add SPDX license header to run_e2e.sh

### DIFF
--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
+#
+# Copyright 2025 bniladridas. All rights reserved.
+# Use of this source code is governed by a MIT license that can be
+# found in the LICENSE file.
 
 echo "Running integration tests..."
 


### PR DESCRIPTION
Adds the standard SPDX license header to the run_e2e.sh script for consistency with other project files.