### PR TITLE
Fix Xcode CocoaPods linking

### DIFF
--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -12,3 +12,6 @@ PRODUCT_BUNDLE_IDENTIFIER = com.example.browser
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2025 com.example. All rights reserved.
+
+// Include CocoaPods configuration for the current build configuration
+#include? "../../Pods/Target Support Files/Pods-Runner/Pods-Runner.$(CONFIGURATION:lower).xcconfig"


### PR DESCRIPTION
Include Pods configurations in AppInfo.xcconfig to resolve module import errors in Xcode.