### PR TITLE
Fix webview controller disposal errors

### DIFF
--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -155,6 +155,17 @@ class _BrowserPageState extends State<BrowserPage> {
     await prefs.setString('bookmarks', jsonEncode(bookmarks));
   }
 
+  void _handleLoadError(String newErrorMessage) {
+    if (mounted) {
+      setState(() {
+        hasError = true;
+        errorMessage = newErrorMessage;
+        isLoading = false;
+        webViewController = null;
+      });
+    }
+  }
+
   void _addBookmark() async {
     if (!bookmarks.contains(currentUrl)) {
       setState(() {
@@ -353,24 +364,10 @@ class _BrowserPageState extends State<BrowserPage> {
               }
             },
             onReceivedError: (controller, request, error) {
-              if (mounted) {
-                setState(() {
-                  hasError = true;
-                  errorMessage = error.description;
-                  isLoading = false;
-                  webViewController = null;
-                });
-              }
+              _handleLoadError(error.description);
             },
             onReceivedHttpError: (controller, request, error) {
-              if (mounted) {
-                setState(() {
-                  hasError = true;
-                  errorMessage = 'HTTP ${error.statusCode}: ${error.reasonPhrase}';
-                  isLoading = false;
-                  webViewController = null;
-                });
-              }
+              _handleLoadError('HTTP ${error.statusCode}: ${error.reasonPhrase}');
             },
           ),
           if (isLoading)


### PR DESCRIPTION
Prevent calling reload on a disposed webview controller by setting it to null when errors occur. This fixes crashes on macOS when pressing refresh after a page load error.