### PR TITLE
fix: add write permission for version bump

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -16,6 +16,8 @@ jobs:
   bump-version:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Add contents: write permission to allow the bot to push tags and commits.