### PR TITLE
fix: fetch tags in version bump

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -23,6 +23,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        fetch-tags: true
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: ./.github/actions/bump-version


### PR DESCRIPTION
Add fetch-tags: true to checkout in version-bump.yml so git describe can find existing tags.