### PR TITLE
fix: fetch all tags in script

### DIFF
--- a/bump_version.sh
+++ b/bump_version.sh
@@ -23,7 +23,7 @@ BUMP_TYPE=$1
 TAG_PREFIX="desktop/app"
 
 # Ensure tags are fetched
-git fetch --all --tags --quiet || true
+git fetch --unshallow --all --tags --quiet || true
 
 # Get latest tag, default to 1.0.0 if none
 if ! LATEST_TAG=$(git describe --tags --abbrev=0 --match "${TAG_PREFIX}-*" 2>/dev/null); then


### PR DESCRIPTION
Change git fetch to --all --tags to ensure tags are available.