### PR TITLE
fix: prevent tag creation if exists

### DIFF
--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -50,14 +50,14 @@ runs:
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
         git add VERSION pubspec.yaml
-        git commit -m "Bump version to $(cat VERSION)" || echo "No changes to commit"
+        git commit -m "Bump version to $(sed 's/+.*//' VERSION)" || echo "No changes to commit"
 
-    - name: Create and push tag if it does not already exist
+    - name: Create and push tag if it does not exist on remote
       shell: bash
       run: |
-        VERSION=$(cat VERSION | sed 's/+.*//')
-        if git rev-parse "desktop/app-${VERSION}" >/dev/null 2>&1; then
-          echo "Tag desktop/app-${VERSION} already exists. Skipping tag creation."
+        VERSION=$(sed 's/+.*//' VERSION)
+        if git ls-remote --tags --exit-code origin "desktop/app-${VERSION}"; then
+          echo "Tag desktop/app-${VERSION} already exists on remote. Skipping tag creation."
         else
           git tag "desktop/app-${VERSION}"
           git push origin "desktop/app-${VERSION}"


### PR DESCRIPTION
Add check to skip tag creation if desktop/app-VERSION already exists, preventing job failure.