### PR TITLE
fix: add pull-requests write permission to version-bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add `pull-requests: write` permission to version-bump workflow
- Fixes "Resource not accessible by integration (createPullRequest)" error
- Allows the workflow to create version bump PRs after merging labeled PRs