### PR TITLE
fix: force push bump branch if exists

### DIFF
--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -95,10 +95,10 @@ runs:
             fi
             git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git config --local user.name "github-actions[bot]"
-            git checkout -b "$BRANCH_NAME"
+            git checkout -B "$BRANCH_NAME"
             git add VERSION pubspec.yaml
             git commit -m "chore: bump version to ${VERSION}"
-            git push -f origin "$BRANCH_NAME"
+            git push --force-with-lease origin "$BRANCH_NAME"
             gh pr create --title "chore: bump version to ${VERSION}" \
             --body "Automated version bump to ${VERSION} after merging PR ${{ inputs.pr-number }}." \
             --base main --head "$BRANCH_NAME"


### PR DESCRIPTION
## Summary
- Change git push -f to --force-with-lease for safer force push
- Change git checkout -b to -B to handle existing local branches
- Improves robustness and prevents accidental overwrites