### PR TITLE
[ci] -- direct fix

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -12,6 +12,10 @@ on:
     types: [closed]
     branches: [main, master]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   bump-version:
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
Add workflow-level permissions to allow GitHub Actions to create pull requests in the version-bump workflow. This fixes the GraphQL error: 'GitHub Actions is not permitted to create or approve pull requests'.