### PR TITLE
`permfix`

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -20,9 +20,6 @@ jobs:
   bump-version:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Remove job-level permissions from the version-bump workflow, keeping only workflow-level permissions to prevent potential conflicts that may prevent PR creation.