### PR TITLE
[DevTools] Add configuration for `shared_preferences`

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright 2025 bniladridas. All rights reserved.
+# Use of this source code is governed by a MIT license that can be
+# found in the LICENSE file.
+
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:
+  - shared_preferences: true


### PR DESCRIPTION
### What changed
- Added devtools_options.yaml to configure DevTools extensions
- Enabled shared_preferences extension for enhanced debugging

### Why
- To provide better debugging tools for shared preferences in the Flutter app
- Improves developer experience during development

### Context
- Related issue / discussion: N/A

### Impact
- User-facing: no
- Breaking change: no

### Notes
- The file follows the project's SPDX license format