### PR TITLE
fix: video restart on tab switch

### DIFF
--- a/lib/features/video_manager.dart
+++ b/lib/features/video_manager.dart
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright 2025 bniladridas. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+class VideoManager {
+  static Future<void> pauseVideos(InAppWebViewController controller) async {
+    debugPrint('Pausing videos');
+    try {
+      await controller.evaluateJavascript(source: """
+        // Save current time and pause HTML5 videos
+        document.querySelectorAll('video').forEach(v => {
+          v.dataset.savedTime = v.currentTime;
+          console.log('Saved time:', v.currentTime);
+          v.pause();
+        });
+        // Pause YouTube videos
+        document.querySelectorAll('iframe').forEach(iframe => {
+          if (iframe.src && iframe.src.includes('youtube.com')) {
+            iframe.contentWindow.postMessage('{"event":"command","func":"pauseVideo","args":""}', '*');
+          }
+        });
+      """);
+    } catch (e) {
+      debugPrint('Error pausing videos: $e');
+      // Ignore errors, e.g., MissingPluginException on macOS
+    }
+  }
+
+  static Future<void> resumeVideos(InAppWebViewController controller) async {
+    debugPrint('Resuming videos');
+    try {
+      await controller.evaluateJavascript(source: """
+        setTimeout(() => {
+          // Resume HTML5 videos from saved time
+          document.querySelectorAll('video').forEach(v => {
+            if (v.dataset.savedTime) {
+              v.currentTime = parseFloat(v.dataset.savedTime);
+              console.log('Restored time:', v.dataset.savedTime);
+            }
+            v.play();
+          });
+          // Resume YouTube videos (seek and play)
+          document.querySelectorAll('iframe').forEach(iframe => {
+            if (iframe.src && iframe.src.includes('youtube.com')) {
+              // Note: YouTube seek requires time, but we can't get it easily; assume play resumes
+              iframe.contentWindow.postMessage('{"event":"command","func":"playVideo","args":""}', '*');
+            }
+          });
+        }, 500);
+      """);
+    } catch (e) {
+      debugPrint('Error resuming videos: $e');
+      // Ignore errors, e.g., MissingPluginException on macOS
+    }
+  }
+}


### PR DESCRIPTION

Summary: YouTube videos restarted from the beginning when switching tabs instead of pausing and resuming from the watched position. This happened because webviews on macOS were deallocating when tabs became inactive, losing video state. Client-side navigation wasn't updating the URL bar, and there was no mechanism to save/restore video playback position.

Fixed by implementing video pause/resume logic with JS injection, adding KeepAliveWrapper to prevent webview deallocation, updating URL handling for SPA navigation, and adding error handling.

Changes:
- Added VideoManager class for pausing/resuming HTML5 and YouTube videos with JS
- Wrapped webviews in KeepAliveWrapper to preserve state across tab switches
- Added onUpdateVisitedHistory callback for URL bar updates on client-side nav
- Included debug logging and try-catch for robust error handling

Tests: All Flutter tests pass, including unit and integration tests. Manually verified video pause/resume on macOS.
