### PR TITLE
fix: spa url bar update and race prevention

### DIFF
--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -857,7 +857,7 @@ class _BrowserPageState extends State<BrowserPage>
           }
         }
         // Update the URL bar for SPA navigation
-        if (mounted && tab.currentUrl != url) {
+        if (!tab.isClosed && mounted && tab.currentUrl != url) {
           setState(() {
             tab.currentUrl = url;
             tab.urlController.text = url;


### PR DESCRIPTION
Closes [https://github.com/bniladridas/browser/issues/109](https://github.com/bniladridas/browser/issues/109)

### What changed

* Update URL bar on SPA navigation by listening to `HistoryChannel` events
* Guard `HistoryChannel` callbacks with `isClosed` to prevent race conditions

### Why

* SPA navigation did not update the URL bar
* Closing tabs could trigger callbacks on disposed controllers

### Impact

* User-facing: yes
* Breaking change: no