### PR TITLE
fix: resolve macOS entitlement error

### DIFF
--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -10,7 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
 import 'dart:convert';
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:http/http.dart' as http;
@@ -21,8 +21,6 @@ import '../features/bookmark_manager.dart';
 
 import '../features/video_manager.dart';
 import '../logging/logger.dart';
-
-const FlutterSecureStorage _secureStorage = FlutterSecureStorage();
 
 const String _modernUserAgent =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0.2 Safari/605.1.15';
@@ -88,22 +86,12 @@ class _SettingsDialogState extends State<SettingsDialog> {
 
   Future<void> _loadCurrentHomepage() async {
     final prefs = await SharedPreferences.getInstance();
-    final homepage = await (() async {
-      String? homepage = await _secureStorage.read(key: homepageKey);
-      if (homepage == null) {
-        homepage = prefs.getString(homepageKey);
-        if (homepage != null) {
-          await _secureStorage.write(key: homepageKey, value: homepage);
-          await prefs.remove(homepageKey);
-        }
-      }
-      return homepage ?? 'https://www.google.com';
-    })();
+    final homepage = prefs.getString(homepageKey) ?? 'https://www.google.com';
     setState(() {
       currentHomepage = homepage;
       homepageController = TextEditingController(text: currentHomepage);
       _hideAppBar = prefs.getBool(hideAppBarKey) ?? false;
-      _useModernUserAgent = prefs.getBool(useModernUserAgentKey) ?? false;
+      _useModernUserAgent = prefs.getBool(useModernUserAgentKey) ?? true;
       _enableGitFetch = prefs.getBool(enableGitFetchKey) ?? false;
       _privateBrowsing = prefs.getBool(privateBrowsingKey) ?? false;
       _originalPrivateBrowsing = _privateBrowsing;
@@ -235,7 +223,7 @@ class _SettingsDialogState extends State<SettingsDialog> {
               return;
             }
             final prefs = await SharedPreferences.getInstance();
-            await _secureStorage.write(key: homepageKey, value: homepage);
+            await prefs.setString(homepageKey, homepage);
             await prefs.setBool(hideAppBarKey, _hideAppBar);
             await prefs.setBool(useModernUserAgentKey, _useModernUserAgent);
             await prefs.setBool(enableGitFetchKey, _enableGitFetch);

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,7 +5,6 @@
 import FlutterMacOS
 import Foundation
 
-import flutter_secure_storage_macos
 import path_provider_foundation
 import screen_retriever_macos
 import shared_preferences_foundation
@@ -13,7 +12,6 @@ import webview_flutter_wkwebview
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,6 +1,4 @@
 PODS:
-  - flutter_secure_storage_macos (6.1.3):
-    - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - path_provider_foundation (0.0.1):
     - Flutter
@@ -17,7 +15,6 @@ PODS:
     - FlutterMacOS
 
 DEPENDENCIES:
-  - flutter_secure_storage_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
@@ -26,8 +23,6 @@ DEPENDENCIES:
   - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
 
 EXTERNAL SOURCES:
-  flutter_secure_storage_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
   path_provider_foundation:
@@ -42,7 +37,6 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
 
 SPEC CHECKSUMS:
-  flutter_secure_storage_macos: 7f45e30f838cf2659862a4e4e3ee1c347c2b3b54
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
   screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -203,54 +203,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
-  flutter_secure_storage:
-    dependency: "direct main"
-    description:
-      name: flutter_secure_storage
-      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.2.4"
-  flutter_secure_storage_linux:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_linux
-      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.3"
-  flutter_secure_storage_macos:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_macos
-      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.3"
-  flutter_secure_storage_platform_interface:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_platform_interface
-      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.2"
-  flutter_secure_storage_web:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_web
-      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.1"
-  flutter_secure_storage_windows:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_windows
-      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -319,14 +271,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -820,14 +764,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.23.5"
-  win32:
-    dependency: transitive
-    description:
-      name: win32
-      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.15.0"
   window_manager:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,8 +43,7 @@ dependencies:
 
   http: ^1.5.0
   shared_preferences: ^2.5.4
-  # Secure storage for sensitive data like homepage URLs
-  flutter_secure_storage: ^9.2.2
+
   path_provider: ^2.1.5
   webview_flutter: ^4.8.0
   logger: ^2.4.0


### PR DESCRIPTION
### Notes
- This change correctly switches to `SharedPreferences` for retrieving the homepage URL. However, it's worth noting that this will cause data loss for existing users who had a custom homepage set.
- The previous logic migrated the homepage setting from `SharedPreferences` to `FlutterSecureStorage`. With `FlutterSecureStorage` now removed, the app can no longer access that migrated value. As a result, the homepage for these users will revert to the default (`https://www.google.com`).

### What changed
- Removed `flutter_secure_storage` dependency
- Replaced secure storage usage with `shared_preferences` for homepage settings
- Updated default user agent to modern for better web compatibility

### Why
- `FlutterSecureStorage` requires keychain entitlements on macOS, causing `PlatformException` -34018
- `SharedPreferences` is sufficient for storing homepage URL (not sensitive data)

### Context
- Related to runtime error on macOS: `PlatformException(Unexpected security result code, Code: -34018, Message: A required entitlement isn't present.)`

### Impact
- User-facing: yes (see Notes)
- Breaking change: no