### PR TITLE
feat[ui] :: apply high-contrast styling rules for accessibility

### DIFF
--- a/pkg/lib/ai_chat_widget.dart
+++ b/pkg/lib/ai_chat_widget.dart
@@ -9,6 +9,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 
 import 'ai_service.dart';
+import 'callout_box.dart';
 
 class AiChatWidget extends HookWidget {
   const AiChatWidget({super.key, this.pageTitle, this.pageUrl});
@@ -69,7 +70,17 @@ class AiChatWidget extends HookWidget {
                   final message = messages.value[index];
                   if (message.startsWith('AI: ')) {
                     final content = message.substring(4);
-                    return ListTile(title: MarkdownBody(data: content));
+                    final hasEmphasis =
+                        content.contains('**') ||
+                        content.contains('*') ||
+                        content.contains('warning') ||
+                        content.contains('error') ||
+                        content.contains('suggestion') ||
+                        content.contains('option');
+                    final child = MarkdownBody(data: content);
+                    return ListTile(
+                      title: hasEmphasis ? CalloutBox(child: child) : child,
+                    );
                   } else {
                     return ListTile(title: Text(message));
                   }

--- a/pkg/lib/callout_box.dart
+++ b/pkg/lib/callout_box.dart
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright 2025 bniladridas. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+class CalloutBox extends StatelessWidget {
+  const CalloutBox({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final brightness = MediaQuery.of(context).platformBrightness;
+    final isDark = brightness == Brightness.dark;
+
+    final backgroundColor =
+        isDark ? const Color(0xFF1e3a5f) : const Color(0xFFcfe8ff);
+    final textColor =
+        isDark ? const Color(0xFFe6f0ff) : const Color(0xFF0b1f33);
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.black.withValues(alpha: 0.1)),
+      ),
+      child: DefaultTextStyle(
+        style: TextStyle(
+          color: textColor,
+          fontWeight: FontWeight.w500,
+          height: 1.4,
+        ),
+        child: child,
+      ),
+    );
+  }
+}

--- a/pkg/lib/pkg.dart
+++ b/pkg/lib/pkg.dart
@@ -1,2 +1,3 @@
 export 'ai_service.dart';
 export 'ai_chat_widget.dart';
+export 'callout_box.dart';


### PR DESCRIPTION
> This PR might need reference to any official page.

## Summary
Adds a `CalloutBox` widget for high-contrast styling in specific scenarios, applied selectively to AI chat responses containing emphasis or keywords.

Example of high-contrast styling on a quota warning:
<img width="788" height="589" alt="Screenshot 2026-01-09 at 5 54 37 PM" src="https://github.com/user-attachments/assets/d6363b75-348f-49d8-8445-e4e4cf9da88e" />

## Changes
- **New file**: `pkg/lib/callout_box.dart` - CalloutBox widget with hardcoded colors for light/dark themes based on platform brightness.
- **Modified**: `pkg/lib/pkg.dart` - Exported CalloutBox.
- **Modified**: `pkg/lib/ai_chat_widget.dart` - Imported CalloutBox and updated to wrap AI responses in CalloutBox when they contain emphasis (markdown bold/italic or keywords like 'warning', 'error', 'suggestion', 'option').

## Usage
Import from the pkg package: 
```dart
import 'package:pkg/callout_box.dart';
```
Use for emphasized content, critical info, AI-generated text, etc., ensuring readability while maintaining visual hierarchy.

Notes: 
- Commit [`f8efbc1`](https://github.com/bniladridas/browser/commit/f8efbc1) contained theme color improvements but was reverted for simplicity.
- Commit [`4d42f86`](https://github.com/bniladridas/browser/commit/4d42f86) contained regex improvements for emphasis detection but was reverted to simplify the logic.