### PR TITLE
fix[security] :: restrict URL schemes to http/https

### DIFF
--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -45,6 +45,11 @@ class UrlUtils {
     return url;
   }
 
+  static bool isValidUrl(String url) {
+    final uri = Uri.tryParse(url);
+    return uri != null && const {'http', 'https'}.contains(uri.scheme);
+  }
+
   static String truncate(String text, int maxLength) {
     if (text.length <= maxLength) return text;
     const ellipsis = '...';
@@ -831,8 +836,7 @@ class _BrowserPageState extends State<BrowserPage>
 
   void _loadUrl(String url) {
     url = UrlUtils.processUrl(url);
-    final uri = Uri.tryParse(url);
-    if (uri == null || !const {'http', 'https'}.contains(uri.scheme)) {
+    if (!UrlUtils.isValidUrl(url)) {
       logger.w('Invalid or unsafe URL: $url');
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Invalid or unsafe URL')),
@@ -842,7 +846,7 @@ class _BrowserPageState extends State<BrowserPage>
     activeTab.currentUrl = url;
     activeTab.urlController.text = url;
     try {
-      activeTab.webViewController?.loadRequest(uri);
+      activeTab.webViewController?.loadRequest(Uri.parse(url));
     } on PlatformException {
       // Ignore MissingPluginException on macOS
     }

--- a/test/url_test.dart
+++ b/test/url_test.dart
@@ -31,5 +31,14 @@ void main() {
       expect(UrlUtils.processUrl('ftp://example.com'), 'ftp://example.com');
       expect(UrlUtils.processUrl('custom://path'), 'custom://path');
     });
+
+    test('should validate safe URLs', () {
+      expect(UrlUtils.isValidUrl('https://example.com'), true);
+      expect(UrlUtils.isValidUrl('http://example.com'), true);
+      expect(UrlUtils.isValidUrl('ftp://example.com'), false);
+      expect(UrlUtils.isValidUrl('javascript:alert(1)'), false);
+      expect(UrlUtils.isValidUrl('data:text/html,<h1>Hi</h1>'), false);
+      expect(UrlUtils.isValidUrl('invalid'), false);
+    });
   });
 }


### PR DESCRIPTION
Restricts URL schemes to http/https only for security, preventing execution of unsafe schemes like `javascript:` or `data:`. Adds `UrlUtils.isValidUrl` method and unit tests.

Part of the security improvements from #146, isolated for focused review.