### PR TITLE
fix[workflow] :: update PR title format to match guidelines

### DIFF
--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -97,9 +97,9 @@ runs:
             git config --local user.name "github-actions[bot]"
             git checkout -B "$BRANCH_NAME"
             git add VERSION pubspec.yaml
-            git commit -m "chore: bump version to ${VERSION}"
+            git commit -m "chore[version] :: bump version to ${VERSION}"
             git push --force-with-lease origin "$BRANCH_NAME"
-            gh pr create --title "chore: bump version to ${VERSION}" \
+            gh pr create --title "chore[version] :: bump version to ${VERSION}" \
             --body "Automated version bump to ${VERSION} after merging PR ${{ inputs.pr-number }}." \
             --base main --head "$BRANCH_NAME"
 


### PR DESCRIPTION
## Summary
- Updated the bump-version workflow action to use the correct PR title format: `type[scope] :: description`
- Changed version bump PR title from `chore: bump version to X.Y.Z` to `chore[version] :: bump version to X.Y.Z`

## Impact
- [x] CI / Workflow

## Notes
Ensures consistency with AGENTS.md guidelines for PR titles.