### PR TITLE
chore[copyright] :: update all headers from 2025 to 2026

### DIFF
--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -1,7 +1,7 @@
 ---
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -1,7 +1,7 @@
 ---
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -1,7 +1,7 @@
 ---
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!-- SPDX-License-Identifier: MIT
 
-Copyright 2025 bniladridas. All rights reserved.
+Copyright 2026 bniladridas. All rights reserved.
 Use of this source code is governed by a MIT license that can be
 found in the LICENSE file. -->
 

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,7 +1,7 @@
 ---
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,7 @@
 ---
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -1,7 +1,7 @@
 ---
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 ---
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,7 +1,7 @@
 ---
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,7 +1,7 @@
 ---
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/add_header.sh
+++ b/add_header.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 
@@ -9,7 +9,7 @@
 
 HEADER="// SPDX-License-Identifier: MIT
 //
-// Copyright 2025 bniladridas. All rights reserved.
+// Copyright 2026 bniladridas. All rights reserved.
 // Use of this source code is governed by a MIT license that can be
 // found in the LICENSE file.
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,7 @@
 ---
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/check.sh
+++ b/check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 set -e

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
-// Copyright 2025 bniladridas. All rights reserved.
+// Copyright 2026 bniladridas. All rights reserved.
 // Use of this source code is governed by a MIT license that can be
 // found in the LICENSE file.
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
-// Copyright 2025 bniladridas. All rights reserved.
+// Copyright 2026 bniladridas. All rights reserved.
 // Use of this source code is governed by a MIT license that can be
 // found in the LICENSE file.
 

--- a/lib/features/bookmark_manager.dart
+++ b/lib/features/bookmark_manager.dart
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
-// Copyright 2025 bniladridas. All rights reserved.
+// Copyright 2026 bniladridas. All rights reserved.
 // Use of this source code is governed by a MIT license that can be
 // found in the LICENSE file.
 

--- a/lib/features/private_browsing.dart
+++ b/lib/features/private_browsing.dart
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
-// Copyright 2025 bniladridas. All rights reserved.
+// Copyright 2026 bniladridas. All rights reserved.
 // Use of this source code is governed by a MIT license that can be
 // found in the LICENSE file.
 

--- a/lib/features/theme_utils.dart
+++ b/lib/features/theme_utils.dart
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
-// Copyright 2025 bniladridas. All rights reserved.
+// Copyright 2026 bniladridas. All rights reserved.
 // Use of this source code is governed by a MIT license that can be
 // found in the LICENSE file.
 

--- a/lib/features/video_manager.dart
+++ b/lib/features/video_manager.dart
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
-// Copyright 2025 bniladridas. All rights reserved.
+// Copyright 2026 bniladridas. All rights reserved.
 // Use of this source code is governed by a MIT license that can be
 // found in the LICENSE file.
 

--- a/lib/logging/logger.dart
+++ b/lib/logging/logger.dart
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
-// Copyright 2025 bniladridas. All rights reserved.
+// Copyright 2026 bniladridas. All rights reserved.
 // Use of this source code is governed by a MIT license that can be
 // found in the LICENSE file.
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
-// Copyright 2025 bniladridas. All rights reserved.
+// Copyright 2026 bniladridas. All rights reserved.
 // Use of this source code is governed by a MIT license that can be
 // found in the LICENSE file.
 

--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
-// Copyright 2025 bniladridas. All rights reserved.
+// Copyright 2026 bniladridas. All rights reserved.
 // Use of this source code is governed by a MIT license that can be
 // found in the LICENSE file.
 

--- a/pkg/lib/ai_chat_widget.dart
+++ b/pkg/lib/ai_chat_widget.dart
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
-// Copyright 2025 bniladridas. All rights reserved.
+// Copyright 2026 bniladridas. All rights reserved.
 // Use of this source code is governed by a MIT license that can be
 // found in the LICENSE file.
 

--- a/pkg/lib/ai_service.dart
+++ b/pkg/lib/ai_service.dart
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
-// Copyright 2025 bniladridas. All rights reserved.
+// Copyright 2026 bniladridas. All rights reserved.
 // Use of this source code is governed by a MIT license that can be
 // found in the LICENSE file.
 

--- a/pkg/lib/callout_box.dart
+++ b/pkg/lib/callout_box.dart
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
-// Copyright 2025 bniladridas. All rights reserved.
+// Copyright 2026 bniladridas. All rights reserved.
 // Use of this source code is governed by a MIT license that can be
 // found in the LICENSE file.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 ---
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/scripts/pubspec.sh
+++ b/scripts/pubspec.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/test/url_test.dart
+++ b/test/url_test.dart
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
-// Copyright 2025 bniladridas. All rights reserved.
+// Copyright 2026 bniladridas. All rights reserved.
 // Use of this source code is governed by a MIT license that can be
 // found in the LICENSE file.
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
-// Copyright 2025 bniladridas. All rights reserved.
+// Copyright 2026 bniladridas. All rights reserved.
 // Use of this source code is governed by a MIT license that can be
 // found in the LICENSE file.
 


### PR DESCRIPTION
## Summary
- Update copyright headers in 35 files from 2025 to 2026

## Impact
- [x] Documentation

## Notes for reviewers
- Automated copyright year update across all source files