### PR TITLE
fix[copyright] :: update remaining 2025 references

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,7 +1,7 @@
 ---
 # SPDX-License-Identifier: MIT
 #
-# Copyright 2025 bniladridas. All rights reserved.
+# Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -11,7 +11,7 @@ PRODUCT_NAME = browser
 PRODUCT_BUNDLE_IDENTIFIER = com.example.browser
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2025 bniladridas. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2026 bniladridas. All rights reserved.
 
 // Include CocoaPods configuration for the current build configuration
 #include? "../../Pods/Target Support Files/Pods-Runner/Pods-Runner.$(CONFIGURATION:lower).xcconfig"


### PR DESCRIPTION
## Summary
- Fix macOS app copyright in AppInfo.xcconfig
- Fix .yamllint copyright header

## Impact
- [x] Documentation

## Notes for reviewers
- Final cleanup of 2025 references