### PR TITLE
fix[ui] :: show error view on load failure

### DIFF
--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -1089,7 +1089,7 @@ class _BrowserPageState extends State<BrowserPage>
   }
 
   Widget _buildTabBody(TabData tab) {
-    if (tab.state is Error) {
+    if (tab.state is BrowserError) {
       return _buildErrorView(tab);
     }
 


### PR DESCRIPTION
## Summary
- Fix error state detection so the custom error view renders on load failures

## Impact
- [x] Build / CI
- [x] Refactor / cleanup
- [ ] Documentation

## Related Items
- Resolves issues: #195
- Closes PRs: #
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers
- The previous `tab.state is Error` check never matched the `BrowserError` union case.

## Review
Reviewed using Graphite Agent
