### PR TITLE
feat[macos] :: add support for unsigned DMG creation

### DIFF
--- a/scripts/macos_release_dmg.sh
+++ b/scripts/macos_release_dmg.sh
@@ -8,22 +8,25 @@ TMP_ROOT="${TMP_ROOT:-}"
 ALLOW_UNSIGNED="${ALLOW_UNSIGNED:-}"
 
 unsigned_release=false
-if [[ -z "${MACOS_CODE_SIGN_IDENTITY:-}" ]]; then
-  if [[ "${ALLOW_UNSIGNED}" == "1" ]]; then
+
+if [[ "${ALLOW_UNSIGNED}" == "1" ]]; then
+  if [[ -z "${MACOS_CODE_SIGN_IDENTITY:-}" ]]; then
     unsigned_release=true
     echo "Warning: MACOS_CODE_SIGN_IDENTITY not set. Proceeding with unsigned DMG." >&2
-  else
+  fi
+
+  if [[ -z "${APPLE_ID:-}" || -z "${APPLE_TEAM_ID:-}" || -z "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]]; then
+    unsigned_release=true
+    echo "Warning: notarization credentials not set. Skipping notarization." >&2
+  fi
+else
+  if [[ -z "${MACOS_CODE_SIGN_IDENTITY:-}" ]]; then
     echo "Missing MACOS_CODE_SIGN_IDENTITY (Developer ID Application identity)." >&2
     echo "Set ALLOW_UNSIGNED=1 to create an unsigned DMG for testing." >&2
     exit 1
   fi
-fi
 
-if [[ -z "${APPLE_ID:-}" || -z "${APPLE_TEAM_ID:-}" || -z "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]]; then
-  if [[ "${ALLOW_UNSIGNED}" == "1" ]]; then
-    unsigned_release=true
-    echo "Warning: notarization credentials not set. Skipping notarization." >&2
-  else
+  if [[ -z "${APPLE_ID:-}" || -z "${APPLE_TEAM_ID:-}" || -z "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]]; then
     echo "Missing APPLE_ID, APPLE_TEAM_ID, or APPLE_APP_SPECIFIC_PASSWORD." >&2
     echo "Set ALLOW_UNSIGNED=1 to create an unsigned DMG for testing." >&2
     exit 1


### PR DESCRIPTION
## Summary
- Add an optional unsigned DMG path for macOS release script via `ALLOW_UNSIGNED=1`
- Preserve existing signed/notarized flow when credentials are provided

## Impact
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation

## Related Items
- Resolves issues: #200
- Closes PRs: #
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)
- Related to: #191

## Notes for reviewers
- Default behavior is unchanged unless `ALLOW_UNSIGNED=1` is set.

## Review
Reviewed using Graphite Agent
