### PR TITLE
feat[ci] :: add cla bot for contributor license agreement

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,20 @@
+---
+# SPDX-License-Identifier: MIT
+#
+# Copyright 2026 bniladridas. All rights reserved.
+# Use of this source code is governed by a MIT license that can be
+# found in the LICENSE file.
+
+name: CLA
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bniladridas/cla-bot@v1.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/cla-signers.json
+++ b/cla-signers.json
@@ -1,0 +1,5 @@
+{
+  "signed": [
+    "bniladridas"
+  ]
+}


### PR DESCRIPTION
## Summary
- Added CLA bot workflow to verify contributors have signed the Contributor License Agreement
- Created `cla-signers.json` with approved contributors list

## Impact
- [x] Build / CI
- [x] Refactor / cleanup
- [ ] Documentation

## Related Items
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers
- CLA bot runs on PR open/sync and checks if author is in `cla-signers.json`
- Passes silently if signed, comments and fails if not