### PR TITLE
fix[cla] :: add checkout step to make signers file available

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,6 +15,10 @@ jobs:
   cla:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            cla-signers.json
       - uses: bniladridas/cla-bot@v1.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add checkout step to CLA workflow to make cla-signers.json available for the bot

## Impact
- [x] CI/CD