### PR TITLE
fix[readme] :: remove duplicate install header

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Flutter desktop web browser with tabs, bookmarks, history.
 
 ## Install
 
-## Install
-
 ```bash
 git clone https://github.com/bniladridas/browser.git
 cd browser


### PR DESCRIPTION
## Summary
- Remove duplicate "Install" header from README.md

## Impact
- [x] Documentation

## Notes for reviewers
- Simple typo fix