### PR TITLE
feat[release] :: add manual workflow dispatch with tag validation and certificate checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,8 +83,17 @@ jobs:
           APP_BUNDLE_ID: ${{ secrets.MACOS_APP_BUNDLE_ID }}
         run: flutter build macos --release 2>&1 | grep -v -E "(firebase_core|firebase_auth|firebase_app_check).*warning"
 
+      - name: Check if certificate is available
+        id: check-cert
+        run: |
+          if [ -n "${{ secrets.MACOS_CERTIFICATE }}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Import signing certificate
-        if: secrets.MACOS_CERTIFICATE != ''
+        if: steps.check-cert.outputs.available == 'true'
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
@@ -107,7 +116,7 @@ jobs:
           MACOS_CODE_SIGN_IDENTITY: ${{ secrets.MACOS_CODE_SIGN_IDENTITY }}
         run: |
           chmod +x ./scripts/macos_release_dmg.sh
-          if [ "${{ secrets.MACOS_CERTIFICATE }}" != "" ] && ./scripts/macos_release_dmg.sh; then
+          if [ "${{ steps.check-cert.outputs.available }}" == "true" ] && ./scripts/macos_release_dmg.sh; then
             echo "status=success" >> "$GITHUB_OUTPUT"
           else
             echo "Trying unsigned build..."


### PR DESCRIPTION
## Hooks

This workflow is designed to integrate cleanly with
[https://github.com/dotfiles-mac/dotfiles](https://github.com/dotfiles-mac/dotfiles)

## Related Items

* **Resolves:** #231 — version bump produced release `1.2.2` without a DMG artifact
* **Related:** Manual workflow trigger failure caused by missing `GoogleService-Info.plist`
  [https://github.com/bniladridas/browser/actions/runs/22525689147/job/65257251450#step:8:19](https://github.com/bniladridas/browser/actions/runs/22525689147/job/65257251450#step:8:19)

## Changes

* Fix macOS build failures by generating a dummy `GoogleService-Info.plist`
* Enable manual release rebuilds via workflow dispatch with tag input
* Conditionally skip signing when required certificates or secrets are unavailable
* Enforce `desktop/app-X.Y.Z` tag format validation
* Checkout the exact tag reference to ensure reproducible builds

## Notes

* Allows safe manual rebuilding and re-attachment of DMG artifacts to existing releases
* Unsigned artifacts are expected when signing credentials are not present