### PR TITLE
ci[project] :: auto-add issues and prs to project

### DIFF
--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -9,9 +9,9 @@ name: Add Items To Project
 
 on:
   issues:
-    types: [opened, reopened]
+    types: [opened, reopened, edited, labeled, unlabeled]
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize, edited, ready_for_review]
 
 jobs:
   add-to-project:


### PR DESCRIPTION
## Summary
- Add new workflow to automatically add newly opened/reopened issues and PRs to GitHub Project 10
- Configure project URL target: `https://github.com/users/bniladridas/projects/10`
- Use `actions/add-to-project@v1.0.2` with repository secret `ADD_TO_PROJECT_PAT`
- Fix action resolution by pinning to a concrete released tag

## Impact
- [x] Build / CI
- [x] Refactor / cleanup
- [ ] Documentation

## Related Items
- Resolves issues: #258
- Closes PRs: N/A
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers
- Review process used: self-review + `yamllint` + `actionlint`
- Required secret already added: `ADD_TO_PROJECT_PAT`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automatic synchronization of issues and pull requests to the project board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->