### PR TITLE
chore[assets] :: treat screenshot folder as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,9 @@ linux/** linguist-generated
 macos/** linguist-generated
 windows/** linguist-generated
 
+# Screenshot assets (binary)
+assets/screenshots/** binary
+
 # Dependency lock files (optional, to reduce noise)
 pubspec.lock linguist-generated
 


### PR DESCRIPTION
## Summary
- Mark `assets/screenshots/**` as binary in `.gitattributes` so diffs stop showing the PNG contents

## Impact
- [ ] Build / CI
- [ ] Refactor / cleanup
- [x] Documentation

## Related Items
- Resolves issues: N/A
- Closes PRs: N/A
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)