### PR TITLE
feat[password] :: origin-safe autofill

### DIFF
--- a/lib/features/password_autofill.dart
+++ b/lib/features/password_autofill.dart
@@ -4,6 +4,7 @@
 // Use of this source code is governed by a MIT license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
 import 'password_storage.dart';
 
 class PasswordAutofillService {
@@ -33,8 +34,9 @@ class PasswordAutofillService {
   }
 
   String generateAutofillScript(String username, String password) {
-    final escapedUsername = username.replaceAll("'", "\\'");
-    final escapedPassword = password.replaceAll("'", "\\'");
+    // Use jsonEncode for proper escaping of all special characters
+    final escapedUsername = jsonEncode(username);
+    final escapedPassword = jsonEncode(password);
 
     return '''
 (function() {
@@ -50,8 +52,8 @@ class PasswordAutofillService {
     const usernameField = form.querySelector('input[type="email"], input[type="text"], input[name*="user"], input[name*="email"], input[id*="user"], input[id*="email"]');
 
     if (usernameField && passwordField) {
-      usernameField.value = '$escapedUsername';
-      passwordField.value = '$escapedPassword';
+      usernameField.value = $escapedUsername;
+      passwordField.value = $escapedPassword;
 
       usernameField.dispatchEvent(new Event('input', { bubbles: true }));
       usernameField.dispatchEvent(new Event('change', { bubbles: true }));

--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -1050,10 +1050,13 @@ class _BrowserPageState extends State<BrowserPage>
     if (!passwordManagerEnabled) return;
 
     try {
+      // Get actual URL from WebView controller, not tab.currentUrl (can be spoofed)
+      if (tab.webViewController == null || tab.isClosed) return;
+      final actualUrl = await tab.webViewController!.currentUrl();
+      if (actualUrl == null) return;
+
       final autofillService = PasswordAutofillService();
-      final matches = await autofillService.getMatchingCredentials(
-        tab.currentUrl,
-      );
+      final matches = await autofillService.getMatchingCredentials(actualUrl);
 
       if (matches.isEmpty) return;
 
@@ -1064,9 +1067,7 @@ class _BrowserPageState extends State<BrowserPage>
         credential.password,
       );
 
-      if (tab.webViewController != null && !tab.isClosed) {
-        await tab.webViewController!.runJavaScript(script);
-      }
+      await tab.webViewController!.runJavaScript(script);
     } catch (e, s) {
       logger.w('Failed to autofill credentials', error: e, stackTrace: s);
     }

--- a/test/features/password_autofill_test.dart
+++ b/test/features/password_autofill_test.dart
@@ -188,33 +188,28 @@ void main() {
     });
 
     group('generateAutofillScript', () {
-      test('should generate script with escaped credentials', () {
+      test('should generate script with JSON-encoded credentials', () {
         final script = service.generateAutofillScript(
           "user@example.com",
           "password123",
         );
 
-        expect(script.contains("user@example.com"), true);
-        expect(script.contains("password123"), true);
+        expect(script.contains('"user@example.com"'), true);
+        expect(script.contains('"password123"'), true);
         expect(script.contains('input[type="password"]'), true);
       });
 
-      test('should escape single quotes in username', () {
+      test('should properly escape quotes and special characters', () {
         final script = service.generateAutofillScript(
           "user'name",
-          "password",
+          'pass"word\\test',
         );
 
-        expect(script.contains("user\\'name"), true);
-      });
-
-      test('should escape single quotes in password', () {
-        final script = service.generateAutofillScript(
-          "username",
-          "pass'word",
-        );
-
-        expect(script.contains("pass\\'word"), true);
+        // jsonEncode wraps in quotes and escapes internal quotes/backslashes
+        expect(script.contains('user'), true);
+        expect(script.contains('pass'), true);
+        // Verify no unescaped quotes that could break JS
+        expect(script.contains("'user'name'"), false);
       });
     });
   });


### PR DESCRIPTION
## Summary
- Add PasswordAutofillService with strict origin matching
- Implement automatic credential filling on page load
- Generate JavaScript to inject credentials into forms
- Respect password manager toggle and private browsing mode
- Use most recently updated credential when multiple matches
- Comprehensive test coverage for origin matching edge cases

## Impact
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests
- [ ] Performance
- [x] Security

## Related Items
- Resolves issues: #252
- Parent tracking: #249
- Depends on: #269, #270 (merged)
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers
- Strict origin matching: scheme + host + port must match exactly
- No cross-origin autofill (subdomains are different origins)
- Disabled in private browsing mode
- Only fills when password manager is enabled
- Escapes single quotes in credentials to prevent JS injection
- 13 new tests covering all origin matching scenarios
- All 39 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic password autofill that securely fills saved credentials when visiting matching websites
  * Autofill respects private browsing mode and user preferences
  * Credentials are matched safely to prevent spoofing attacks

* **Tests**
  * Added comprehensive test coverage for autofill functionality including credential matching and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->