### PR TITLE
fix[drag-drop] :: allow file scheme for local files

### DIFF
--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -678,6 +678,7 @@ class _BrowserPageState extends State<BrowserPage>
     'about',
     'blob',
     'data',
+    'file',
   };
 
   late TabController tabController;


### PR DESCRIPTION
## Summary
- Add 'file' to allowed navigation schemes
- Fixes white page when dragging and dropping local files
- Regression from recent tab reordering changes

## Impact
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Related to #227 (original drag-and-drop implementation)
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers
- File scheme was blocked causing drag-dropped files to show white page
- Now allows file:// URLs to load properly
- PR #227 originally added drag-and-drop support with file:// handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for file:// URL navigation, enabling users to navigate to local file URLs in addition to web-based protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->