### PR TITLE
feat[ui] :: add fade-in animation for macOS window startup

### DIFF
--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -11,5 +11,16 @@ class MainFlutterWindow: NSWindow {
     RegisterGeneratedPlugins(registry: flutterViewController)
 
     super.awakeFromNib()
+
+    // Hide window initially
+    self.alphaValue = 0
+
+    // Show after Flutter initializes
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+      NSAnimationContext.runAnimationGroup({ context in
+        context.duration = 0.2
+        self.animator().alphaValue = 1.0
+      }, completionHandler: nil)
+    }
   }
 }


### PR DESCRIPTION
Fixes #291

Hides the startup UI flash by delaying window visibility until Flutter and window_manager have initialized.

## Changes
- Window starts invisible (alphaValue = 0)
- Waits 150ms for Flutter/WebView and window_manager initialization
- Fades in smoothly over 200ms after configuration is applied

## Impact
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Resolves issues: #291