### PR TITLE
fix[license] :: remove characters override with CC BY-SA license

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,3 @@ Fork, branch, edit, commit, PR.
 ## License
 This project is proprietary software. See [LICENSE](LICENSE) for full terms.
 Copyright (c) 2026 Niladri Das (bniladridas). All Rights Reserved.
-
-
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fbniladridas%2Fbrowser.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fbniladridas%2Fbrowser?ref=badge_large) [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fbniladridas%2Fbrowser.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fbniladridas%2Fbrowser?ref=badge_shield)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -98,7 +98,7 @@ packages:
     source: hosted
     version: "8.12.4"
   characters:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: characters
       sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,7 +78,6 @@ dependency_overrides:
   # Overrides to resolve warnings about outdated transitive dependencies.
   # These can likely be removed when direct dependencies are updated.
   # See issue #94.
-  characters: ^1.4.1
   material_color_utilities: ^0.13.0
   matcher: ^0.12.18
   test_api: ^0.7.8


### PR DESCRIPTION
Removes the `characters` package override that had a CC BY-SA 3.0 license, which is incompatible with proprietary software due to its ShareAlike clause.

## Changes
- Removed `characters: ^1.4.1` from dependency_overrides
- Flutter will now use its bundled characters package with a permissive license
- Updated pubspec.lock
- Removed FOSSA badges from README

## Impact
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [x] Security

## Related Items
- Resolves FOSSA license issue with CC BY-SA 3.0