### PR TITLE
fix[macos] :: harden dmg script parsing

### DIFF
--- a/scripts/macos_release_dmg.sh
+++ b/scripts/macos_release_dmg.sh
@@ -9,6 +9,7 @@ ALLOW_UNSIGNED="${ALLOW_UNSIGNED:-}"
 DMG_WINDOW_BOUNDS="${DMG_WINDOW_BOUNDS:-100,100,640,420}"
 DMG_ICON_SIZE="${DMG_ICON_SIZE:-128}"
 DMG_BACKGROUND_IMAGE="${DMG_BACKGROUND_IMAGE:-assets/dmg/background.png}"
+DMG_HEADROOM_MB="${DMG_HEADROOM_MB:-50}"
 
 unsigned_release=false
 
@@ -82,7 +83,11 @@ fi
 
 # Include extra headroom for metadata, icon layout and optional background.
 size_mb="$(du -sm "${dmg_root}" | awk '{print $1}')"
-size_mb="$((size_mb + 50))"
+if [[ ! "${DMG_HEADROOM_MB}" =~ ^[0-9]+$ ]]; then
+  echo "Invalid DMG_HEADROOM_MB: ${DMG_HEADROOM_MB} (expected integer)." >&2
+  exit 1
+fi
+size_mb="$((size_mb + DMG_HEADROOM_MB))"
 
 hdiutil create \
   -volname "${VOLUME_NAME}" \


### PR DESCRIPTION
## Summary
- Harden `scripts/macos_release_dmg.sh` AppleScript calls by using quoted heredocs and argv instead of interpolated shell variables.
- Improve mounted DMG path parsing to support `/Volumes/...` paths containing spaces.
- Reduce temporary DMG sizing headroom from `+200MB` to `+50MB`.

## Impact
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [x] Security

## Related Items
- Resolves #336
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers
- Runtime app behavior is unchanged; this only affects macOS release DMG packaging.
- Review process: self-review + automated pre-commit checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized macOS DMG release packaging with reduced file size overhead.
  * Improved reliability of DMG mount point handling.
  * Enhanced application shortcut creation in DMG with better fallback mechanisms.
  * Streamlined window customization in the DMG interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->