### PR TITLE
ci[release] :: pin dmg env defaults

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,8 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           MACOS_CODE_SIGN_IDENTITY: ${{ secrets.MACOS_CODE_SIGN_IDENTITY }}
+          DMG_BACKGROUND_IMAGE: assets/dmg/background.png
+          DMG_HEADROOM_MB: '50'
         run: |
           chmod +x ./scripts/macos_release_dmg.sh
           if [ "${{ steps.check-cert.outputs.available }}" == "true" ] && ./scripts/macos_release_dmg.sh; then


### PR DESCRIPTION
## Summary
- Add explicit `DMG_BACKGROUND_IMAGE` and `DMG_HEADROOM_MB` env vars to the release workflow DMG step.
- Keep release-time DMG behavior deterministic even if script defaults are changed later.

## Impact
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Resolves #340
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers
- Change is workflow-only (`.github/workflows/release.yml`).
- Review process: self-review + yamllint + pre-commit checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS installer configuration for improved build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->