### PR TITLE
feat[ui] :: add offline indicator when internet connection is lost

### DIFF
--- a/lib/features/connectivity_service.dart
+++ b/lib/features/connectivity_service.dart
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright 2026 bniladridas. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+class ConnectivityService {
+  final Connectivity _connectivity = Connectivity();
+
+  Stream<bool> get onConnectivityChanged {
+    return _connectivity.onConnectivityChanged.map((result) {
+      return result.any((r) => r != ConnectivityResult.none);
+    });
+  }
+
+  Future<bool> checkConnectivity() async {
+    final result = await _connectivity.checkConnectivity();
+    return result.any((r) => r != ConnectivityResult.none);
+  }
+}

--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -28,6 +28,7 @@ import '../features/theme_utils.dart';
 import '../features/bookmark_manager.dart';
 import '../features/password_prompt.dart';
 import '../features/password_storage.dart';
+import '../features/connectivity_service.dart';
 import '../features/password_autofill.dart';
 import '../features/login_detection.dart';
 import '../features/webauthn_script.dart';
@@ -949,6 +950,9 @@ class _BrowserPageState extends State<BrowserPage>
   final bookmarkManager = BookmarkManager();
   late int previousTabIndex;
   List<RegExp> adBlockerPatterns = [];
+  bool _isOnline = true;
+  final ConnectivityService _connectivityService = ConnectivityService();
+  StreamSubscription<bool>? _connectivitySubscription;
   final Set<String> _downloadableExtensions = {
     'dmg',
     'zip',
@@ -1145,6 +1149,23 @@ class _BrowserPageState extends State<BrowserPage>
     if (widget.aiAvailable && !isIntegrationTest) {
       _aiService = AiService();
     }
+    _initConnectivity();
+  }
+
+  void _initConnectivity() async {
+    _isOnline = await _connectivityService.checkConnectivity();
+    if (mounted) {
+      setState(() {}); // Update UI with initial state
+    }
+
+    _connectivitySubscription =
+        _connectivityService.onConnectivityChanged.listen((isOnline) {
+      if (mounted && _isOnline != isOnline) {
+        setState(() {
+          _isOnline = isOnline;
+        });
+      }
+    });
   }
 
   TabData _createTab(String initialUrl) {
@@ -2452,6 +2473,7 @@ class _BrowserPageState extends State<BrowserPage>
 
   @override
   void dispose() {
+    _connectivitySubscription?.cancel();
     _overflowMenuCloseTimer?.cancel();
     _windowButtonsSyncRetryTimer?.cancel();
     WidgetsBinding.instance.removeObserver(this);
@@ -4758,6 +4780,42 @@ class _BrowserPageState extends State<BrowserPage>
                                 ),
                               ),
                             ],
+                          ),
+                        ),
+                      ),
+                    if (!_isOnline)
+                      Positioned(
+                        top: widget.hideAppBar ? 16 : 0,
+                        left: 0,
+                        right: 0,
+                        child: Material(
+                          color: Theme.of(context).colorScheme.errorContainer,
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 16,
+                              vertical: 8,
+                            ),
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Icon(
+                                  Icons.wifi_off,
+                                  size: 16,
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onErrorContainer,
+                                ),
+                                const SizedBox(width: 8),
+                                Text(
+                                  'No internet connection',
+                                  style: TextStyle(
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .onErrorContainer,
+                                  ),
+                                ),
+                              ],
+                            ),
                           ),
                         ),
                       ),

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import connectivity_plus
 import desktop_drop
 import device_info_plus
 import file_selector_macos
@@ -20,6 +21,7 @@ import webview_flutter_wkwebview
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -3,6 +3,8 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
+  - connectivity_plus (0.0.1):
+    - FlutterMacOS
   - desktop_drop (0.0.1):
     - FlutterMacOS
   - device_info_plus (0.0.1):
@@ -102,6 +104,7 @@ PODS:
     - FlutterMacOS
 
 DEPENDENCIES:
+  - connectivity_plus (from `Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos`)
   - desktop_drop (from `Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos`)
   - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
   - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
@@ -133,6 +136,8 @@ SPEC REPOS:
     - PromisesObjC
 
 EXTERNAL SOURCES:
+  connectivity_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos
   desktop_drop:
     :path: Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos
   device_info_plus:
@@ -164,6 +169,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
+  connectivity_plus: 4adf20a405e25b42b9c9f87feff8f4b6fde18a4e
   desktop_drop: 10a3e6a7fa9dbe350541f2574092fecfa345a07b
   device_info_plus: 4fb280989f669696856f8b129e4a5e3cd6c48f76
   file_selector_macos: 9e9e068e90ebee155097d00e89ae91edb2374db7

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -145,6 +145,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: "33bae12a398f841c6cda09d1064212957265869104c478e5ad51e2fb26c3973c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   convert:
     dependency: transitive
     description:
@@ -177,6 +193,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.6"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.12"
   desktop_drop:
     dependency: "direct main"
     description:
@@ -671,6 +695,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.17.4"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   objective_c:
     dependency: transitive
     description:
@@ -823,6 +855,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   pkg:
     dependency: "direct main"
     description:
@@ -1211,6 +1251,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
   pkg:
     path: ./pkg
   passkeys: ^2.17.4
+  connectivity_plus: ^7.0.0
 
 
 dev_dependencies:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <desktop_drop/desktop_drop_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
@@ -16,6 +17,8 @@
 #include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  ConnectivityPlusWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   DesktopDropPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DesktopDropPlugin"));
   FileSelectorWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  connectivity_plus
   desktop_drop
   file_selector_windows
   firebase_auth


### PR DESCRIPTION
Fixes #344

Adds a visual indicator when the internet connection is lost.

## Changes
- Added `connectivity_plus` package for network monitoring
- Created `ConnectivityService` to track connection status
- Added offline banner at the top of the browser showing "No internet connection"
- Banner appears automatically when connection is lost and disappears when restored

## Impact
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Resolves #344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time internet connectivity monitoring that continuously tracks your connection status and responds to changes instantly.
  * The app now displays a clear offline banner when internet connectivity is lost, helping you understand service limitations.
  * Improved app behavior during network disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->