### PR TITLE
fix[ci] :: add dummy google service plist

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,7 +37,7 @@ jobs:
           } > .env
       - name: Create GoogleService-Info.plist
         run: |
-          cat > macos/Runner/GoogleService-Info.plist << 'EOF'
+          cat << 'EOF' | sed 's/^          //' > macos/Runner/GoogleService-Info.plist
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -35,7 +35,7 @@ jobs:
             } > .env
       - name: Create dummy GoogleService-Info.plist for CI
         run: |
-          cat > macos/Runner/GoogleService-Info.plist <<EOF
+          cat <<'EOF' | sed 's/^          //' > macos/Runner/GoogleService-Info.plist
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Create dummy GoogleService-Info.plist
         run: |
           mkdir -p macos/Runner
-          cat > macos/Runner/GoogleService-Info.plist << 'EOF'
+          cat << 'EOF' | sed 's/^          //' > macos/Runner/GoogleService-Info.plist
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -35,7 +35,7 @@ jobs:
           } > .env
       - name: Create dummy GoogleService-Info.plist for macOS
         run: |
-          cat > macos/Runner/GoogleService-Info.plist << 'EOF'
+          cat << 'EOF' | sed 's/^          //' > macos/Runner/GoogleService-Info.plist
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">


### PR DESCRIPTION
It was flaky.

## Summary
- Add a workflow step that creates a dummy macOS `GoogleService-Info.plist` before running `flutter pub run build_runner`, so the macOS CI job no longer fails when Firebase config is missing.

## Impact
- [x] Bug fix
- [x] Build / CI
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers
- None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows updated to create a dummy macOS GoogleService-Info.plist during runs so macOS builds and tests run reliably in CI.
  * Plist generation now normalizes embedded file indentation before writing to ensure consistent formatting across workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->