### PR TITLE
chore: update guidelines to prevent add in commits and prs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,9 +87,17 @@ Follow the repository's pre-commit hooks for commit messages:
 - Use conventional commit format without scope punctuation: `type: description`
 - Keep the first line lowercase
 - Keep the first line concise (max 40 characters) to satisfy hook checks
+- NEVER use the word "add" in commit messages - Use alternative verbs like "integrate", "implement", "include", "attach", "configure", "setup", "enable", "support", etc.
 - Examples:
-  - `feat: add crashlytics integration`
-  - `fix: resolve button alignment`
+  - `feat: add crashlytics integration` (NOT ALLOWED)
+  - `feat: integrate crashlytics for crash reporting` (USE THIS INSTEAD)
+  - `fix: add button alignment fix` (NOT ALLOWED)
+  - `fix: resolve button alignment issue` (USE THIS INSTEAD)
+
+Validation Rule: Before committing, verify the commit message does not contain the word "add" (case-insensitive). Use:
+```bash
+git log --oneline -1 | grep -i "add" && echo "ERROR: Commit message contains 'add'" || echo "OK"
+```
 
 Agents must adhere to these rules to pass CI checks. Do not use --no-verify or bypass hooks; fix issues to ensure code quality.
 
@@ -259,10 +267,17 @@ This is because Firebase tries to initialize with invalid configuration.
 Use the `gh pr create` command with the full PR body in HEREDOC format:
 
 ```bash
+# Validate PR title does not contain "add"
+PR_TITLE="<your-pr-title>"
+if echo "$PR_TITLE" | grep -qi "add"; then
+  echo "ERROR: PR title contains 'add'. Use alternative verbs like integrate, implement, include, etc."
+  exit 1
+fi
+
 gh pr create \
   --base main \
   --head <branch-name> \
-  --title "<pr-title>" \
+  --title "$PR_TITLE" \
   --body "$(cat <<'EOF'
 ## Summary
 - Bullet point descriptions of changes
@@ -289,4 +304,4 @@ EOF
 )"
 ```
 
-This ensures proper formatting with multiline body text.
+This ensures proper formatting with multiline body text and validates that PR titles do not contain "add".


### PR DESCRIPTION
## Summary
- Updated AGENTS.md to prevent the word "add" in commit messages
- Added validation in commit message guidelines to use alternative verbs
- Added PR title validation to reject titles containing "add"
- Provided examples of allowed and disallowed commit messages

## Impact
- [x] Refactor / cleanup
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Resolves AGENTS.md update to prevent "add" in commits

## Notes for reviewers
- This PR adds documentation/guidelines only, no code changes
- The validation command is provided for agents to use before committing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated commit message and PR title guidelines to restrict the use of "add" with examples of preferred alternative phrasing.
  * Added validation checks to enforce compliance with updated commit and PR title standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->