### PR TITLE
feat[media] :: enable camera and microphone permissions on macOS

### DIFF
--- a/.opencode/config.yaml
+++ b/.opencode/config.yaml
@@ -27,7 +27,7 @@ pr:
     validation:
       command: "printf \"%s\\n\" \"$PR_TITLE\" | grep -qiw \"add\""
       errorMessage: "PR title contains prohibited word 'add'. Use alternatives like integrate, implement, include, etc."
-  
+
   description:
     template: "templates/pr-description.md"
     sections:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,10 +312,10 @@ gh pr create \
 > ```bash
 > # Should match (contains standalone "add")
 > printf "%s\n" "fix: add address handling" | grep -qiw "add" && echo "FOUND" || echo "NOT FOUND"
-> 
+>
 > # Should NOT match (no standalone "add")
 > printf "%s\n" "fix: integrate address handling" | grep -qiw "add" && echo "FOUND" || echo "NOT FOUND"
-> 
+>
 > # Should NOT match (contains "padding" not "add")
 > printf "%s\n" "fix: padding issue" | grep -qiw "add" && echo "FOUND" || echo "NOT FOUND"
 > ```
@@ -325,7 +325,7 @@ gh pr create \
 > ```bash
 > # Test with prohibited word
 > printf "%s\n" "feat: add crashlytics integration" | grep -qiw "add" && echo "ERROR: Contains 'add'" || echo "OK"
-> 
+>
 > # Test with allowed alternative
 > printf "%s\n" "feat: integrate crashlytics for crash reporting" | grep -qiw "add" && echo "ERROR: Contains 'add'" || echo "OK"
 > ```
@@ -335,7 +335,7 @@ gh pr create \
 > ```bash
 > # This PR title (valid)
 > printf "%s\n" "chore[guidelines] :: integrate commit message and pr title validation" | grep -E "^(feat|fix|docs|refactor|chore|deps|perf|ci|build|revert)\[[a-zA-Z0-9]+\]\ ::\ .+" && echo "Format valid" || echo "Format invalid"
-> 
+>
 > # This would be invalid (contains "add")
 > printf "%s\n" "chore[guidelines] :: add validation for pr titles" | grep -qiw "add" && echo "Contains prohibited word" || echo "OK"
 > ```

--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -2431,6 +2431,30 @@ class _BrowserPageState extends State<BrowserPage>
     }));
   }
 
+  Future<void> _handlePermissionRequest(
+    TabData tab,
+    WebViewPermissionRequest request,
+  ) async {
+    const allowedMediaPermissions = {
+      WebViewPermissionResourceType.camera,
+      WebViewPermissionResourceType.microphone,
+    };
+    final requestedTypes = request.types;
+    final granted = requestedTypes.isNotEmpty &&
+        requestedTypes.every(allowedMediaPermissions.contains);
+    final sanitizedUrl = _sanitizeUrlForLog(tab.currentUrl);
+    final typeList = requestedTypes.map((type) => type.name).join(', ');
+    logger.d(
+      'WebView permission ${granted ? 'granted' : 'denied'} '
+      'for $sanitizedUrl [${typeList.isEmpty ? '<none>' : typeList}]',
+    );
+    if (granted) {
+      await request.grant();
+      return;
+    }
+    await request.deny();
+  }
+
   bool _shouldIgnoreWebResourceError(WebResourceError error) {
     // Subresource failures should not replace the full page with an error view.
     if (error.isForMainFrame == false) {
@@ -4696,7 +4720,15 @@ class _BrowserPageState extends State<BrowserPage>
     }
 
     if (tab.webViewController == null) {
-      tab.webViewController = WebViewController();
+      final shouldHookPermissions =
+          defaultTargetPlatform != TargetPlatform.iOS;
+      tab.webViewController = WebViewController(
+        onPermissionRequest: shouldHookPermissions
+            ? (request) {
+                unawaited(_handlePermissionRequest(tab, request));
+              }
+            : null,
+      );
       tab.webViewController!.setJavaScriptMode(widget.strictMode
           ? JavaScriptMode.disabled
           : JavaScriptMode.unrestricted);

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -10,5 +10,9 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -30,6 +30,10 @@
 	<string>NSApplication</string>
 	<key>io.flutter.embedded_views_preview</key>
 	<string>YES</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Allow camera access so web content can capture video when requested.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Allow microphone access so web content can capture audio when requested.</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Enable camera and microphone permissions for macOS builds
- Hook WebView permission handler only on safe platforms and grant only when every requested type is camera/microphone
- Added `com.apple.security.device.camera` and `com.apple.security.device.audio-input` entitlements plus privacy descriptions so macOS prompts correctly

## Impact
- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Resolves #381
- Resolves camera/microphone access for web sites requiring media

## Notes for reviewers
- Grant requests only when each requested permission is camera or microphone to avoid accidentally approving unrelated resources
- Permission hook now skips iOS so it doesn’t trigger media prompts until Info.plist keys exist
- Manual test: open a WebRTC-heavy site (Meet/Zoom) and confirm camera/mic prompts appear on macOS while sites run normally elsewhere