### PR TITLE
chore[flutter] :: upgrade flutter to 3.41.5 and reduce webauthn verbose logging

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -12,7 +12,7 @@ inputs:
   flutter-version:
     description: 'Flutter version to install'
     required: true
-    default: '3.41.4'
+    default: '3.41.5'
 
 runs:
   using: 'composite'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-flutter
         with:
-          flutter-version: '3.41.4'
+          flutter-version: '3.41.5'
       - run: flutter pub get
       - name: Generate code
         run: flutter pub run build_runner build --delete-conflicting-outputs

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-flutter
         with:
-          flutter-version: '3.41.4'
+          flutter-version: '3.41.5'
       - run: flutter pub get
       - name: Create .env file
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: ./.github/actions/setup-flutter
         with:
-          flutter-version: '3.41.4'
+          flutter-version: '3.41.5'
 
       - run: flutter pub get
       - name: Create .env file

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-flutter
         with:
-          flutter-version: '3.41.4'
+          flutter-version: '3.41.5'
       - run: flutter pub get
       - name: Create .env file
         run: |

--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -2373,9 +2373,8 @@ class _BrowserPageState extends State<BrowserPage>
     String? type;
     int? requestId;
     try {
-      // Check if it's a status message (not JSON)
+      // Skip status messages - they're internal initialization noise
       if (!message.startsWith('{')) {
-        logger.i('WebAuthn status: $message');
         return;
       }
 
@@ -2384,7 +2383,7 @@ class _BrowserPageState extends State<BrowserPage>
       requestId = data['requestId'] as int;
       final options = data['options'] as Map<String, dynamic>;
 
-      logger.i('WebAuthn request: $type (ID: $requestId)');
+      logger.d('WebAuthn request: $type (ID: $requestId)');
 
       final webAuthnService = WebAuthnService();
 
@@ -5049,7 +5048,6 @@ class _BrowserPageState extends State<BrowserPage>
       });
       tab.webViewController!.addJavaScriptChannel('WebAuthnChannel',
           onMessageReceived: (JavaScriptMessage message) async {
-        logger.i('WebAuthn message received');
         _handleWebAuthnMessage(tab, message.message);
       });
       tab.webViewController!.setNavigationDelegate(NavigationDelegate(


### PR DESCRIPTION
Posh emojis: 😲🐛

## Summary
- Upgrade Flutter from 3.41.4 to 3.41.5 across all CI workflows (e2e, flutter, release, ui-test, setup-flutter action)
- Reduce WebAuthn verbose logging by removing "WebAuthn message received" and status logs that clutter terminal output
- Change WebAuthn internal status messages from info to debug level

## Impact
- [x] Build / CI
- [x] Refactor / cleanup

## Related Items
- Resolves #416
- Closes #417 (URL bar selection verified working - no code changes needed)

## Notes for reviewers
- Flutter upgrade is a patch version bump (3.41.4 -> 3.41.5)
- WebAuthn logging changes are non-functional improvements for better developer experience