### PR TITLE
feat[core] :: implement user profiles for isolated browsing data

### DIFF
--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -40,6 +40,13 @@ Future<void> _launchApp(WidgetTester tester,
     await prefs.setString(whatsNewSeenVersionKey, info.version.trim());
   }
 
+  if (resetPrefs) {
+    profileManager.resetForTesting();
+  }
+  if (profileManager.activeProfileId == null) {
+    await profileManager.initialize();
+  }
+
   await tester
       .pumpWidget(MyApp(aiAvailable: false, enableGitFetch: enableGitFetch));
   await tester.pumpAndSettle();
@@ -537,6 +544,131 @@ void main() {
       );
       expect(reopenedApiKeyField.controller?.text, 'test-api-key');
       expect(reopenedAppIdField.controller?.text, 'test-app-id');
+    }, timeout: testTimeout);
+
+    testWidgets('Profile section appears in Settings',
+        (WidgetTester tester) async {
+      await _launchApp(tester);
+
+      await openOverflowMenu(tester);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Settings'));
+      await tester.pumpAndSettle();
+
+      final settingsScrollable = find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.byType(Scrollable),
+      );
+      await tester.scrollUntilVisible(
+        find.text('Profiles'),
+        100,
+        scrollable: settingsScrollable.first,
+      );
+
+      expect(find.text('Profiles'), findsOneWidget);
+    }, timeout: testTimeout);
+
+    testWidgets('Profile manager opens and displays profiles',
+        (WidgetTester tester) async {
+      await _launchApp(tester);
+
+      await openOverflowMenu(tester);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Settings'));
+      await tester.pumpAndSettle();
+
+      final settingsScrollable = find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.byType(Scrollable),
+      );
+      await tester.scrollUntilVisible(
+        find.text('Profiles'),
+        100,
+        scrollable: settingsScrollable.first,
+      );
+      await tester.tap(find.text('Manage'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Manage Profiles'), findsOneWidget);
+      expect(find.text('Close'), findsOneWidget);
+    }, timeout: testTimeout);
+
+    testWidgets('Profile manager shows create dialog UI',
+        (WidgetTester tester) async {
+      await _launchApp(tester);
+
+      await openOverflowMenu(tester);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Settings'));
+      await tester.pumpAndSettle();
+
+      final settingsScrollable = find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.byType(Scrollable),
+      );
+      await tester.scrollUntilVisible(
+        find.text('Profiles'),
+        100,
+        scrollable: settingsScrollable.first,
+      );
+      await tester.tap(find.text('Manage'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Create new profile'), findsOneWidget);
+      await tester.tap(find.text('Create new profile'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Create Profile'), findsOneWidget);
+      expect(find.text('Profile name'), findsOneWidget);
+      expect(find.byType(TextField), findsWidgets);
+    }, timeout: testTimeout);
+
+    testWidgets('Can switch between profiles', (WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues({});
+      profileManager.resetForTesting();
+      await profileManager.initialize();
+      await profileManager.createProfile('Work');
+
+      await _launchApp(tester, resetPrefs: true);
+
+      await openOverflowMenu(tester);
+      await tester.pumpAndSettle();
+
+      if (find.text('Settings').evaluate().isNotEmpty) {
+        await tester.tap(find.text('Settings'));
+        await tester.pumpAndSettle();
+
+        final settingsScrollable = find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.byType(Scrollable),
+        );
+        await tester.scrollUntilVisible(
+          find.text('Profiles'),
+          100,
+          scrollable: settingsScrollable.first,
+        );
+        await tester.tap(find.text('Manage'));
+        await tester.pumpAndSettle();
+
+        if (find.text('Work').evaluate().isNotEmpty) {
+          await tester.tap(find.text('Work'));
+          await tester.pumpAndSettle();
+          expect(profileManager.activeProfile?.name, 'Work');
+        }
+      }
+    }, timeout: testTimeout);
+
+    testWidgets('Profile persists after app restart',
+        (WidgetTester tester) async {
+      final uniqueName = 'Persistent_${DateTime.now().millisecondsSinceEpoch}';
+      SharedPreferences.setMockInitialValues({});
+      profileManager.resetForTesting();
+      await profileManager.initialize();
+      await profileManager.createProfile(uniqueName);
+
+      await _launchApp(tester, resetPrefs: false);
+
+      expect(profileManager.profiles.any((p) => p.name == uniqueName), isTrue);
     }, timeout: testTimeout);
   }, skip: Platform.isLinux || Platform.isWindows);
 }

--- a/lib/features/profile_manager.dart
+++ b/lib/features/profile_manager.dart
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright 2026 bniladridas. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/user_profile.dart';
+import '../constants.dart';
+
+class ProfileManager extends ChangeNotifier {
+  static const String _profilesKey = 'user_profiles';
+  static const String _activeProfileIdKey = 'active_profile_id';
+  static const String _defaultProfileId = 'default';
+
+  SharedPreferences? _prefs;
+  List<UserProfile> _profiles = [];
+  String? _activeProfileId;
+
+  List<UserProfile> get profiles => List.unmodifiable(_profiles);
+  String? get activeProfileId => _activeProfileId;
+  UserProfile? get activeProfile =>
+      _profiles.where((p) => p.id == _activeProfileId).firstOrNull;
+
+  Future<void> initialize() async {
+    _prefs = await SharedPreferences.getInstance();
+    await _loadProfiles();
+    await _ensureDefaultProfile();
+  }
+
+  Future<void> _loadProfiles() async {
+    final profilesJson = _prefs?.getString(_profilesKey);
+    if (profilesJson != null) {
+      try {
+        final List<dynamic> decoded = jsonDecode(profilesJson);
+        _profiles = decoded
+            .map((e) => UserProfile.fromJson(e as Map<String, dynamic>))
+            .toList();
+      } catch (e) {
+        _profiles = [];
+        if (_prefs != null) {
+          await _prefs!.remove(_profilesKey);
+        }
+      }
+    }
+    _activeProfileId = _prefs?.getString(_activeProfileIdKey);
+  }
+
+  Future<void> _saveProfiles() async {
+    if (_prefs == null) {
+      throw StateError(
+          'ProfileManager._saveProfiles: _prefs is null. Call initialize() first.');
+    }
+    final json = jsonEncode(_profiles.map((p) => p.toJson()).toList());
+    await _prefs!.setString(_profilesKey, json);
+  }
+
+  Future<void> _setActiveProfileId(String id) async {
+    if (_prefs == null) {
+      throw StateError(
+          'ProfileManager._setActiveProfileId: _prefs is null. Call initialize() first.');
+    }
+    _activeProfileId = id;
+    await _prefs!.setString(_activeProfileIdKey, id);
+    await _prefs!.reload();
+  }
+
+  Future<void> _ensureDefaultProfile() async {
+    if (_profiles.isEmpty) {
+      final defaultProfile = UserProfile(
+        id: _defaultProfileId,
+        name: 'Default',
+        colorValue: UserProfile.availableColors[0],
+        createdAt: DateTime.now(),
+      );
+      _profiles.add(defaultProfile);
+      await _setActiveProfileId(defaultProfile.id);
+      await _saveProfiles();
+    } else if (_activeProfileId == null ||
+        !_profiles.any((p) => p.id == _activeProfileId)) {
+      await _setActiveProfileId(_profiles.first.id);
+    }
+  }
+
+  Future<UserProfile> createProfile(String name, {int? colorValue}) async {
+    final id = 'profile_${DateTime.now().millisecondsSinceEpoch}';
+    final profile = UserProfile(
+      id: id,
+      name: name,
+      colorValue: colorValue ??
+          UserProfile.availableColors[
+              _profiles.length % UserProfile.availableColors.length],
+      createdAt: DateTime.now(),
+    );
+    _profiles.add(profile);
+    await _saveProfiles();
+    notifyListeners();
+    return profile;
+  }
+
+  Future<void> updateProfile(UserProfile profile) async {
+    final index = _profiles.indexWhere((p) => p.id == profile.id);
+    if (index != -1) {
+      _profiles[index] = profile;
+      await _saveProfiles();
+      notifyListeners();
+    }
+  }
+
+  Future<void> deleteProfile(String id) async {
+    if (id == _defaultProfileId) return;
+
+    final index = _profiles.indexWhere((p) => p.id == id);
+    if (index == -1) return;
+
+    _profiles.removeAt(index);
+
+    if (_activeProfileId == id) {
+      await _setActiveProfileId(_profiles.first.id);
+    }
+
+    await _saveProfiles();
+    notifyListeners();
+  }
+
+  Future<void> switchProfile(String id) async {
+    if (_profiles.any((p) => p.id == id) && id != _activeProfileId) {
+      await _setActiveProfileId(id);
+      notifyListeners();
+    }
+  }
+
+  bool canDelete(String id) => id != _defaultProfileId;
+
+  String getProfileStorageKey(String key) {
+    if (_activeProfileId == null) {
+      throw StateError(
+          'ProfileManager.getProfileStorageKey: _activeProfileId is null. Call initialize() first.');
+    }
+    return '${_activeProfileId}_$key';
+  }
+
+  String get bookmarksKey => getProfileStorageKey(bookmarksStorageKey);
+  String get historyKey => getProfileStorageKey(browsingHistoryKey);
+
+  void resetForTesting() {
+    _prefs = null;
+    _profiles = [];
+    _activeProfileId = null;
+    notifyListeners();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,7 @@ import 'package:window_manager/window_manager.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'logging/logger.dart';
 import 'features/theme_utils.dart';
+import 'features/profile_manager.dart';
 import 'ux/browser_page.dart';
 import 'package:pkg/ai_service.dart';
 import 'constants.dart';
@@ -386,6 +387,8 @@ class _MyAppState extends State<MyApp> {
   }
 }
 
+final ProfileManager profileManager = ProfileManager();
+
 void main() async {
   runZonedGuarded(() async {
     WidgetsFlutterBinding.ensureInitialized();
@@ -421,6 +424,11 @@ void main() async {
       }
     } else {
       logger.i('Skipping window manager initialization in integration mode.');
+    }
+    try {
+      await profileManager.initialize();
+    } catch (e) {
+      logger.e('Profile manager initialization failed: $e');
     }
     if (!isIntegrationTest) {
       try {

--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright 2026 bniladridas. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:ui';
+
+class UserProfile {
+  final String id;
+  final String name;
+  final int colorValue;
+  final DateTime createdAt;
+
+  const UserProfile({
+    required this.id,
+    required this.name,
+    required this.colorValue,
+    required this.createdAt,
+  });
+
+  Color get color => Color(colorValue);
+
+  UserProfile copyWith({
+    String? id,
+    String? name,
+    int? colorValue,
+    DateTime? createdAt,
+  }) {
+    return UserProfile(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      colorValue: colorValue ?? this.colorValue,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'colorValue': colorValue,
+        'createdAt': createdAt.toIso8601String(),
+      };
+
+  factory UserProfile.fromJson(Map<String, dynamic> json) {
+    final id = json['id'] is String ? json['id'] as String : '';
+    final name = json['name'] is String ? json['name'] as String : '';
+    int colorValue;
+    if (json['colorValue'] is int) {
+      colorValue = json['colorValue'] as int;
+    } else if (json['colorValue'] is num) {
+      colorValue = (json['colorValue'] as num).toInt();
+    } else {
+      colorValue = availableColors[0];
+    }
+    DateTime createdAt;
+    if (json['createdAt'] is String) {
+      createdAt =
+          DateTime.tryParse(json['createdAt'] as String) ?? DateTime.now();
+    } else {
+      createdAt = DateTime.now();
+    }
+    return UserProfile(
+      id: id,
+      name: name,
+      colorValue: colorValue,
+      createdAt: createdAt,
+    );
+  }
+
+  String toJsonString() => jsonEncode(toJson());
+
+  factory UserProfile.fromJsonString(String jsonString) {
+    return UserProfile.fromJson(jsonDecode(jsonString) as Map<String, dynamic>);
+  }
+
+  static const List<int> availableColors = [
+    0xFF4285F4, // Blue
+    0xFFEA4335, // Red
+    0xFF34A853, // Green
+    0xFFFBBC05, // Yellow
+    0xFF9334E6, // Purple
+    0xFFFF6D01, // Orange
+    0xFF46BDC6, // Teal
+    0xFFE91E63, // Pink
+  ];
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UserProfile &&
+          runtimeType == other.runtimeType &&
+          id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
+}

--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -38,6 +38,8 @@ import '../features/login_detection.dart';
 import '../features/webauthn_script.dart';
 import '../features/webauthn_service.dart';
 import '../browser_state.dart';
+import '../main.dart' show profileManager;
+import '../models/user_profile.dart';
 
 import '../logging/logger.dart';
 import '../logging/network_monitor.dart';
@@ -512,6 +514,59 @@ class SettingsDialog extends HookWidget {
                       ),
                     ),
                   ),
+                  const SizedBox(height: 4),
+                  Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                    child: Row(
+                      children: [
+                        Text(
+                          'Profiles',
+                          style: theme.textTheme.titleSmall?.copyWith(
+                            fontSize: 11,
+                            fontWeight: FontWeight.w600,
+                            color: theme.colorScheme.primary,
+                          ),
+                        ),
+                        const Spacer(),
+                        MouseRegion(
+                          cursor: SystemMouseCursors.click,
+                          child: TextButton(
+                            onPressed: () => _showProfileManagerDialog(
+                                context, ambientToolbarEnabled.value),
+                            style: TextButton.styleFrom(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 8),
+                              minimumSize: const Size(0, 24),
+                            ),
+                            child: const Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(Icons.settings, size: 14),
+                                SizedBox(width: 4),
+                                Text('Manage'),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: ListenableBuilder(
+                      listenable: profileManager,
+                      builder: (context, _) => Text(
+                        'Active: ${profileManager.activeProfile?.name ?? "None"}',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          fontSize: 10,
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  const Divider(),
                   MouseRegion(
                     cursor: SystemMouseCursors.click,
                     child: SwitchListTile(
@@ -1015,6 +1070,305 @@ class SettingsDialog extends HookWidget {
           child: const Text('Save'),
         ),
       ],
+    );
+  }
+
+  void _showProfileManagerDialog(BuildContext dialogContext, bool ambient) {
+    showDialog<void>(
+      context: dialogContext,
+      builder: (context) => _ProfileManagerDialog(
+        onProfileChanged: () {},
+        ambientEnabled: ambient,
+      ),
+    );
+  }
+}
+
+class _ProfileManagerDialog extends StatefulWidget {
+  final VoidCallback onProfileChanged;
+  final bool ambientEnabled;
+
+  const _ProfileManagerDialog({
+    required this.onProfileChanged,
+    required this.ambientEnabled,
+  });
+
+  @override
+  State<_ProfileManagerDialog> createState() => _ProfileManagerDialogState();
+}
+
+class _ProfileManagerDialogState extends State<_ProfileManagerDialog> {
+  final noHoverOverlay = WidgetStateProperty.resolveWith<Color?>((states) {
+    return states.contains(WidgetState.hovered) ? Colors.transparent : null;
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return AlertDialog(
+      backgroundColor: widget.ambientEnabled
+          ? theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.9)
+          : null,
+      title: const Text('Manage Profiles'),
+      content: SizedBox(
+        width: 300,
+        child: Theme(
+          data: theme.copyWith(
+            splashFactory: NoSplash.splashFactory,
+            hoverColor: Colors.transparent,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListenableBuilder(
+                listenable: profileManager,
+                builder: (context, _) => ConstrainedBox(
+                  constraints: const BoxConstraints(maxHeight: 200),
+                  child: SingleChildScrollView(
+                    child: Column(
+                      children: profileManager.profiles.map((profile) {
+                        final isActive =
+                            profile.id == profileManager.activeProfileId;
+                        return Material(
+                          color: Colors.transparent,
+                          child: InkWell(
+                            onTap: isActive
+                                ? null
+                                : () async {
+                                    await profileManager
+                                        .switchProfile(profile.id);
+                                    widget.onProfileChanged();
+                                    if (mounted) setState(() {});
+                                  },
+                            hoverColor: Colors.transparent,
+                            splashColor: Colors.transparent,
+                            highlightColor: Colors.transparent,
+                            child: ListTile(
+                              dense: true,
+                              hoverColor: Colors.transparent,
+                              selectedColor: profile.color,
+                              selected: isActive,
+                              leading: CircleAvatar(
+                                radius: 12,
+                                backgroundColor: profile.color,
+                                child: Text(
+                                  profile.name.isNotEmpty
+                                      ? profile.name[0].toUpperCase()
+                                      : '?',
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 10,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ),
+                              title: Text(profile.name),
+                              trailing: isActive
+                                  ? Icon(Icons.check,
+                                      size: 18, color: profile.color)
+                                  : profileManager.canDelete(profile.id)
+                                      ? IconButton(
+                                          icon: const Icon(Icons.delete_outline,
+                                              size: 18),
+                                          onPressed: () =>
+                                              _confirmDelete(profile),
+                                        )
+                                      : null,
+                            ),
+                          ),
+                        );
+                      }).toList(),
+                    ),
+                  ),
+                ),
+              ),
+              const Divider(),
+              Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  onTap: _showCreateProfileDialog,
+                  hoverColor: Colors.transparent,
+                  splashColor: Colors.transparent,
+                  highlightColor: Colors.transparent,
+                  child: const ListTile(
+                    dense: true,
+                    leading: Icon(Icons.add),
+                    title: Text('Create new profile'),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          style: ButtonStyle(overlayColor: noHoverOverlay),
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
+
+  void _showCreateProfileDialog() {
+    final nameController = TextEditingController();
+    int? selectedColorIndex;
+    final theme = Theme.of(context);
+
+    final dialogTheme = theme.copyWith(
+      splashFactory: NoSplash.splashFactory,
+      highlightColor: Colors.transparent,
+      hoverColor: Colors.transparent,
+      inputDecorationTheme: theme.inputDecorationTheme.copyWith(
+        hoverColor: Colors.transparent,
+      ),
+    );
+    showDialog<void>(
+      context: context,
+      builder: (context) => Theme(
+        data: dialogTheme,
+        child: StatefulBuilder(
+          builder: (context, setStateDialog) => AlertDialog(
+            title: const Text('Create Profile'),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                TextField(
+                  controller: nameController,
+                  onTap: () {
+                    nameController.selection = TextSelection.collapsed(
+                      offset: nameController.text.length,
+                    );
+                  },
+                  decoration: InputDecoration(
+                    labelText: 'Profile name',
+                    hintText: 'Enter profile name',
+                    isDense: true,
+                    filled: false,
+                    enabledBorder: UnderlineInputBorder(
+                      borderSide: BorderSide(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    focusedBorder: UnderlineInputBorder(
+                      borderSide: BorderSide(
+                        color: theme.colorScheme.primary,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'Color',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+                const SizedBox(height: 8),
+                Wrap(
+                  spacing: 8,
+                  children: List.generate(UserProfile.availableColors.length,
+                      (index) {
+                    final color = UserProfile.availableColors[index];
+                    return Material(
+                      color: Colors.transparent,
+                      child: InkWell(
+                        onTap: () {
+                          setStateDialog(() {
+                            selectedColorIndex = index;
+                          });
+                        },
+                        hoverColor: Colors.transparent,
+                        splashColor: Colors.transparent,
+                        highlightColor: Colors.transparent,
+                        child: CircleAvatar(
+                          radius: 12,
+                          backgroundColor: Color(color),
+                          child: selectedColorIndex == index
+                              ? const Icon(Icons.check,
+                                  size: 14, color: Colors.white)
+                              : null,
+                        ),
+                      ),
+                    );
+                  }),
+                ),
+              ],
+            ),
+            actions: [
+              TextButton(
+                style: ButtonStyle(overlayColor: noHoverOverlay),
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Cancel'),
+              ),
+              TextButton(
+                style: ButtonStyle(overlayColor: noHoverOverlay),
+                onPressed: () async {
+                  if (nameController.text.trim().isNotEmpty) {
+                    final colorValue = selectedColorIndex != null
+                        ? UserProfile.availableColors[selectedColorIndex!]
+                        : null;
+                    await profileManager.createProfile(
+                      nameController.text.trim(),
+                      colorValue: colorValue,
+                    );
+                    if (mounted) {
+                      Navigator.pop(context);
+                      setState(() {});
+                    }
+                  }
+                },
+                child: const Text('Create'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _confirmDelete(UserProfile profile) {
+    final dialogTheme = Theme.of(context).copyWith(
+      splashFactory: NoSplash.splashFactory,
+      hoverColor: Colors.transparent,
+    );
+    showDialog<void>(
+      context: context,
+      builder: (context) => Theme(
+        data: dialogTheme,
+        child: AlertDialog(
+          title: Text('Erase ${profile.name}?'),
+          content: Text(
+            'All browsing data for this profile will be lost.',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          actions: [
+            TextButton(
+              style: ButtonStyle(overlayColor: noHoverOverlay),
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              style: ButtonStyle(
+                overlayColor: noHoverOverlay,
+              ),
+              onPressed: () async {
+                await profileManager.deleteProfile(profile.id);
+                widget.onProfileChanged();
+                if (mounted) {
+                  Navigator.pop(context);
+                  setState(() {});
+                }
+              },
+              child: Text(
+                'Erase',
+                style: TextStyle(color: Colors.red.shade600),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
@@ -1595,6 +1949,7 @@ class _BrowserPageState extends State<BrowserPage>
     tabController.addListener(_onTabChanged);
     _loadBookmarks();
     _loadHistory();
+    profileManager.addListener(_onProfileChanged);
     if (widget.adBlocking) {
       loadAdBlockers();
     }
@@ -1987,6 +2342,14 @@ class _BrowserPageState extends State<BrowserPage>
       } else {
         widget.onPageThemeChanged?.call(ThemeMode.system, null);
       }
+    }
+    if (oldWidget.privateBrowsing && !widget.privateBrowsing) {
+      _loadBookmarks();
+      _loadHistory();
+    }
+    if (!oldWidget.privateBrowsing && widget.privateBrowsing) {
+      bookmarkManager.clear();
+      _history.clear();
     }
   }
 
@@ -3171,6 +3534,7 @@ class _BrowserPageState extends State<BrowserPage>
     _removeUrlAutocompleteOverlay(updatePointerEvents: false);
     _overflowMenuCloseTimer?.cancel();
     _windowButtonsSyncRetryTimer?.cancel();
+    profileManager.removeListener(_onProfileChanged);
     WidgetsBinding.instance.removeObserver(this);
     _keyboardFocusNode.dispose();
     for (final tab in tabs) {
@@ -3203,28 +3567,38 @@ class _BrowserPageState extends State<BrowserPage>
   }
 
   Future<void> _loadBookmarks() async {
+    if (widget.privateBrowsing) return;
+    final bookmarksKey = profileManager.bookmarksKey;
     final prefs = await SharedPreferences.getInstance();
-    final bookmarksJson = prefs.getString(bookmarksStorageKey);
+    if (profileManager.bookmarksKey != bookmarksKey) return;
+    final bookmarksJson = prefs.getString(bookmarksKey);
     if (bookmarksJson != null) {
       try {
         bookmarkManager.load(bookmarksJson);
       } catch (e, s) {
         logger.w('Failed to load bookmarks', error: e, stackTrace: s);
-        await prefs.remove(bookmarksStorageKey);
+        if (profileManager.bookmarksKey == bookmarksKey) {
+          await prefs.remove(bookmarksKey);
+        }
       }
     }
   }
 
   Future<void> _saveBookmarks() async {
     if (widget.privateBrowsing) return;
+    final bookmarksKey = profileManager.bookmarksKey;
+    final data = bookmarkManager.save();
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(bookmarksStorageKey, bookmarkManager.save());
+    if (profileManager.bookmarksKey != bookmarksKey) return;
+    await prefs.setString(bookmarksKey, data);
   }
 
   Future<void> _loadHistory() async {
     if (widget.privateBrowsing) return;
+    final historyKey = profileManager.historyKey;
     final prefs = await SharedPreferences.getInstance();
-    final historyJson = prefs.getString(browsingHistoryKey);
+    if (profileManager.historyKey != historyKey) return;
+    final historyJson = prefs.getString(historyKey);
     if (historyJson == null || historyJson.trim().isEmpty) {
       return;
     }
@@ -3247,8 +3621,21 @@ class _BrowserPageState extends State<BrowserPage>
 
   Future<void> _saveHistory() async {
     if (widget.privateBrowsing) return;
+    final historyKey = profileManager.historyKey;
+    final data = jsonEncode(_history);
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(browsingHistoryKey, jsonEncode(_history));
+    if (profileManager.historyKey != historyKey) return;
+    await prefs.setString(historyKey, data);
+  }
+
+  void _onProfileChanged() {
+    if (!mounted) return;
+    if (widget.privateBrowsing) return;
+    bookmarkManager.clear();
+    _history.clear();
+    _loadBookmarks();
+    _loadHistory();
+    setState(() {});
   }
 
   void _recordHistory(TabData tab, String url) {
@@ -3687,13 +4074,22 @@ class _BrowserPageState extends State<BrowserPage>
         context: context,
         barrierDismissible: true,
         barrierLabel: 'Settings',
-        barrierColor: Colors.black54,
+        barrierColor: _ambientActive ? Colors.transparent : Colors.black54,
         transitionDuration: const Duration(milliseconds: 200),
         pageBuilder: (context, animation, secondaryAnimation) {
+          final theme = Theme.of(context);
           return Align(
             alignment: Alignment.centerRight,
             child: Material(
               type: MaterialType.transparency,
+              color: _ambientActive
+                  ? theme.colorScheme.surfaceContainerHighest
+                      .withValues(alpha: 0.95)
+                  : null,
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(12),
+                bottomLeft: Radius.circular(12),
+              ),
               child: SettingsDialog(
                 onSettingsChanged: () {
                   _loadReorderableTabs();
@@ -4554,11 +4950,6 @@ class _BrowserPageState extends State<BrowserPage>
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    'Search or URL',
-                    style: theme.textTheme.titleSmall?.copyWith(fontSize: 13),
-                  ),
-                  const SizedBox(height: 8),
                   TextFormField(
                     initialValue: inputValue,
                     autofocus: true,

--- a/test/ux/profile_manager_test.dart
+++ b/test/ux/profile_manager_test.dart
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright 2026 bniladridas. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+import 'package:browser/constants.dart';
+import 'package:browser/features/profile_manager.dart';
+import 'package:browser/features/theme_utils.dart';
+import 'package:browser/main.dart';
+import 'package:browser/models/user_profile.dart';
+import 'package:browser/ux/browser_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ProfileManager', () {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      profileManager.resetForTesting();
+      await profileManager.initialize();
+    });
+
+    test('creates default profile on first initialize', () {
+      expect(profileManager.profiles.length, 1);
+      expect(profileManager.profiles.first.id, 'default');
+      expect(profileManager.profiles.first.name, 'Default');
+      expect(profileManager.activeProfileId, 'default');
+    });
+
+    test('creates new profile with custom name', () async {
+      final profile = await profileManager.createProfile('Work');
+
+      expect(profileManager.profiles.length, 2);
+      expect(profile.name, 'Work');
+      expect(profileManager.profiles.last.name, 'Work');
+    });
+
+    test('creates new profile with selected color', () async {
+      final profile = await profileManager.createProfile('Personal',
+          colorValue: 0xFFEA4335);
+
+      expect(profile.colorValue, 0xFFEA4335);
+    });
+
+    test('switchProfile changes active profile', () async {
+      final workProfile = await profileManager.createProfile('Work');
+      await profileManager.switchProfile(workProfile.id);
+
+      expect(profileManager.activeProfileId, workProfile.id);
+      expect(profileManager.activeProfile?.name, 'Work');
+    });
+
+    test('switchProfile does nothing for same profile', () async {
+      final activeBefore = profileManager.activeProfileId;
+      await profileManager.switchProfile(activeBefore!);
+
+      expect(profileManager.activeProfileId, activeBefore);
+    });
+
+    test('deleteProfile removes profile', () async {
+      final workProfile = await profileManager.createProfile('WorkDelete');
+      final countBefore = profileManager.profiles.length;
+
+      await profileManager.deleteProfile(workProfile.id);
+
+      expect(profileManager.profiles.length, countBefore - 1);
+      expect(
+          profileManager.profiles.any((p) => p.name == 'WorkDelete'), isFalse);
+    });
+
+    test('deleteProfile cannot delete default profile', () {
+      expect(profileManager.canDelete('default'), isFalse);
+      expect(profileManager.canDelete('fake_id'), isTrue);
+    });
+
+    test('deleteProfile switches to default if deleting active', () async {
+      final workProfile = await profileManager.createProfile('Work');
+      await profileManager.switchProfile(workProfile.id);
+
+      await profileManager.deleteProfile(workProfile.id);
+
+      expect(profileManager.activeProfileId, 'default');
+    });
+
+    test('profile storage keys are scoped by active profile', () {
+      expect(profileManager.bookmarksKey, 'default_$bookmarksStorageKey');
+      expect(profileManager.historyKey, 'default_$browsingHistoryKey');
+    });
+
+    test('profile storage keys change with active profile', () async {
+      final workProfile = await profileManager.createProfile('Work');
+      await profileManager.switchProfile(workProfile.id);
+
+      expect(profileManager.bookmarksKey,
+          '${workProfile.id}_$bookmarksStorageKey');
+      expect(
+          profileManager.historyKey, '${workProfile.id}_$browsingHistoryKey');
+    });
+
+    test('notifies listeners on profile creation and switch', () async {
+      int notifyCount = 0;
+      profileManager.addListener(() => notifyCount++);
+
+      final workProfile = await profileManager.createProfile('Work');
+      expect(notifyCount, 1);
+
+      await profileManager.switchProfile(workProfile.id);
+      expect(notifyCount, 2);
+    });
+
+    test('persists active profile', () async {
+      final newPm = ProfileManager();
+      SharedPreferences.setMockInitialValues({
+        'user_profiles':
+            '[{"id":"profile_test","name":"Test","colorValue":4285,"createdAt":"2024-01-01T00:00:00.000","isActive":false}]',
+        'active_profile_id': 'profile_test',
+      });
+      await newPm.initialize();
+
+      expect(newPm.activeProfileId, 'profile_test');
+      expect(newPm.profiles.length, 1);
+    });
+  });
+
+  group('UserProfile model', () {
+    test('creates profile from JSON', () {
+      final json = {
+        'id': 'test_id',
+        'name': 'Test Profile',
+        'colorValue': 0xFF4285F4,
+        'createdAt': '2024-01-01T00:00:00.000',
+      };
+
+      final profile = UserProfile.fromJson(json);
+
+      expect(profile.id, 'test_id');
+      expect(profile.name, 'Test Profile');
+      expect(profile.colorValue, 0xFF4285F4);
+    });
+
+    test('converts profile to JSON', () {
+      final profile = UserProfile(
+        id: 'test_id',
+        name: 'Test Profile',
+        colorValue: 0xFF4285F4,
+        createdAt: DateTime(2024, 1, 1),
+      );
+
+      final json = profile.toJson();
+
+      expect(json['id'], 'test_id');
+      expect(json['name'], 'Test Profile');
+      expect(json['colorValue'], 0xFF4285F4);
+      expect(json.containsKey('isActive'), isFalse);
+    });
+
+    test('available colors list is not empty', () {
+      expect(UserProfile.availableColors, isNotEmpty);
+      expect(UserProfile.availableColors.length, greaterThanOrEqualTo(8));
+    });
+
+    test('profile equality based on id', () {
+      final profile1 = UserProfile(
+        id: 'same_id',
+        name: 'Profile 1',
+        colorValue: 0xFF4285F4,
+        createdAt: DateTime.now(),
+      );
+
+      final profile2 = UserProfile(
+        id: 'same_id',
+        name: 'Profile 2',
+        colorValue: 0xFFEA4335,
+        createdAt: DateTime.now(),
+      );
+
+      expect(profile1, equals(profile2));
+    });
+  });
+
+  group('Profile Manager Dialog UI', () {
+    testWidgets('displays profile section in Settings', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      profileManager.resetForTesting();
+      await profileManager.initialize();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                return TextButton(
+                  onPressed: () {
+                    showDialog<void>(
+                      context: context,
+                      builder: (_) => SettingsDialog(
+                        aiAvailable: false,
+                        currentTheme: AppThemeMode.system,
+                      ),
+                    );
+                  },
+                  child: const Text('Open'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Profiles'), findsWidgets);
+    });
+  });
+}

--- a/test/ux/settings_dialog_test.dart
+++ b/test/ux/settings_dialog_test.dart
@@ -107,16 +107,25 @@ void main() {
         ),
       );
 
-      await tester.tap(_switchTileByTitle('Legacy User Agent'));
-      await tester.pumpAndSettle();
-      await tester.tap(_switchTileByTitle('AI Search Suggestions'));
-      await tester.pumpAndSettle();
-
-      final darkChip = find.widgetWithText(ChoiceChip, 'dark');
       final settingsScrollable = find.descendant(
         of: find.byType(AlertDialog),
         matching: find.byType(Scrollable),
       );
+
+      await tester.tap(_switchTileByTitle('Legacy User Agent'));
+      await tester.pumpAndSettle();
+
+      if (settingsScrollable.evaluate().isNotEmpty) {
+        await tester.scrollUntilVisible(
+          _switchTileByTitle('AI Search Suggestions'),
+          120,
+          scrollable: settingsScrollable.first,
+        );
+      }
+      await tester.tap(_switchTileByTitle('AI Search Suggestions'));
+      await tester.pumpAndSettle();
+
+      final darkChip = find.widgetWithText(ChoiceChip, 'dark');
       if (settingsScrollable.evaluate().isNotEmpty) {
         await tester.scrollUntilVisible(
           darkChip,


### PR DESCRIPTION
## Summary
- Implement user profiles feature for browser to support isolated browsing data per profile
- Create ProfileManager service with ChangeNotifier for reactive UI updates
- Add UserProfile model with customizable name and color
- Integrate profile-scoped storage for bookmarks and history
- Add profile management UI in Settings dialog
- Add unit tests (17 tests) and integration tests (5 tests)

## Impact
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Resolves #420

## Notes for reviewers
- Profiles enable multiple users to have separate browsing data (bookmarks, history)
- Each profile has a customizable name and color
- Profile switching is instant and persists across app restarts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profiles: create, switch, and delete named/colorized profiles from Settings; active profile shown live and persisted across launches.
  * Manage Profiles dialog and Create Profile flow added.
  * Bookmarks and history are now scoped per active profile with profile-specific storage keys.

* **Bug Fixes**
  * Bookmark/history loading now respects private browsing and profile changes; settings visuals adjusted for ambient mode; Quick URL prompt title removed.
  
* **Tests**
  * New integration, widget, and unit tests covering profiles, UI flows, persistence, and model serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->