### PR TITLE
feat[profiles] :: implement profile-scoped settings with legacy migration

### DIFF
--- a/lib/features/profile_manager.dart
+++ b/lib/features/profile_manager.dart
@@ -16,6 +16,8 @@ class ProfileManager extends ChangeNotifier {
   static const String _profilesKey = 'user_profiles';
   static const String _activeProfileIdKey = 'active_profile_id';
   static const String _defaultProfileId = 'default';
+  static const String _legacySettingsMigratedKey =
+      'profile_settings_legacy_migrated_v1';
 
   SharedPreferences? _prefs;
   List<UserProfile> _profiles = [];
@@ -30,6 +32,7 @@ class ProfileManager extends ChangeNotifier {
     _prefs = await SharedPreferences.getInstance();
     await _loadProfiles();
     await _ensureDefaultProfile();
+    await _migrateLegacySettingsToDefaultProfile();
   }
 
   Future<void> _loadProfiles() async {
@@ -86,6 +89,70 @@ class ProfileManager extends ChangeNotifier {
     }
   }
 
+  Future<void> _migrateLegacySettingsToDefaultProfile() async {
+    final prefs = _prefs;
+    if (prefs == null) return;
+    if (prefs.getBool(_legacySettingsMigratedKey) == true) return;
+
+    Future<void> migrateLegacyValue<T>({
+      required String key,
+      required T? legacyValue,
+      required Future<bool> Function(String scopedKey, T value) writeScoped,
+    }) async {
+      if (legacyValue == null) return;
+      final scopedKey = '${_defaultProfileId}_$key';
+      if (!prefs.containsKey(scopedKey)) {
+        final success = await writeScoped(scopedKey, legacyValue);
+        if (!success) {
+          debugPrint(
+              'ProfileManager: Failed to migrate legacy pref "$key" to "$scopedKey". Leaving legacy key intact.');
+          return;
+        }
+      }
+      await prefs.remove(key);
+    }
+
+    const boolKeys = <String>[
+      hideAppBarKey,
+      useModernUserAgentKey,
+      enableGitFetchKey,
+      privateBrowsingKey,
+      adBlockingKey,
+      strictModeKey,
+      passwordManagerEnabledKey,
+      reorderableTabsKey,
+      aiSearchSuggestionsEnabledKey,
+      advancedCacheEnabledKey,
+      ambientToolbarEnabledKey,
+    ];
+
+    const stringKeys = <String>[
+      homepageKey,
+      themeModeKey,
+      pageFontFamilyKey,
+      pageFontOverridesKey,
+      navigationCacheIndexKey,
+    ];
+
+    for (final key in boolKeys) {
+      await migrateLegacyValue<bool>(
+        key: key,
+        legacyValue: prefs.getBool(key),
+        writeScoped: prefs.setBool,
+      );
+    }
+
+    for (final key in stringKeys) {
+      await migrateLegacyValue<String>(
+        key: key,
+        legacyValue: prefs.getString(key),
+        writeScoped: prefs.setString,
+      );
+    }
+
+    await prefs.setBool(_legacySettingsMigratedKey, true);
+  }
+
   Future<UserProfile> createProfile(String name, {int? colorValue}) async {
     final id = 'profile_${DateTime.now().millisecondsSinceEpoch}';
     final profile = UserProfile(
@@ -123,8 +190,25 @@ class ProfileManager extends ChangeNotifier {
       await _setActiveProfileId(_profiles.first.id);
     }
 
+    await _erasePrefsForProfile(id);
     await _saveProfiles();
     notifyListeners();
+  }
+
+  Future<void> _erasePrefsForProfile(String profileId) async {
+    final prefs = _prefs;
+    if (prefs == null) {
+      throw StateError(
+          'ProfileManager._erasePrefsForProfile: _prefs is null. Call initialize() first.');
+    }
+    final prefix = '${profileId}_';
+    final keysToRemove = prefs
+        .getKeys()
+        .where((key) => key.startsWith(prefix))
+        .toList(growable: false);
+    for (final key in keysToRemove) {
+      await prefs.remove(key);
+    }
   }
 
   Future<void> switchProfile(String id) async {
@@ -142,6 +226,17 @@ class ProfileManager extends ChangeNotifier {
           'ProfileManager.getProfileStorageKey: _activeProfileId is null. Call initialize() first.');
     }
     return '${_activeProfileId}_$key';
+  }
+
+  /// Returns a profile-scoped key when a profile is active; otherwise returns
+  /// the input key unchanged.
+  ///
+  /// Use this for settings storage in contexts (like widget tests) where the
+  /// profile manager may not be initialized.
+  String getScopedStorageKey(String key) {
+    final id = _activeProfileId;
+    if (id == null || id.isEmpty) return key;
+    return '${id}_$key';
   }
 
   String get bookmarksKey => getProfileStorageKey(bookmarksStorageKey);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,6 +46,8 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   static const String _whatsNewAssetPath = 'assets/whats_new.json';
 
+  String? _lastSettingsProfileId;
+
   AppThemeMode themeMode = AppThemeMode.system;
   AppThemeMode? previewThemeMode;
   ThemeMode adjustedThemeMode = ThemeMode.system;
@@ -68,9 +70,24 @@ class _MyAppState extends State<MyApp> {
   void initState() {
     super.initState();
     _loadSettings();
+    _lastSettingsProfileId = profileManager.activeProfileId;
+    profileManager.addListener(_handleProfileManagerChange);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _maybeShowWhatsNew();
     });
+  }
+
+  @override
+  void dispose() {
+    profileManager.removeListener(_handleProfileManagerChange);
+    super.dispose();
+  }
+
+  void _handleProfileManagerChange() {
+    final current = profileManager.activeProfileId;
+    if (current == _lastSettingsProfileId) return;
+    _lastSettingsProfileId = current;
+    _loadSettings();
   }
 
   Future<void> _maybeShowWhatsNew() async {
@@ -174,31 +191,52 @@ class _MyAppState extends State<MyApp> {
 
   Future<void> _loadSettings() async {
     final prefs = await SharedPreferences.getInstance();
+    String scopedKey(String key) => profileManager.getScopedStorageKey(key);
+    bool readBool(String key, {required bool defaultValue}) =>
+        prefs.getBool(scopedKey(key)) ?? defaultValue;
+
+    String? readString(String key) => prefs.getString(scopedKey(key));
+
     if (mounted) {
+      final storedHomepage = readString(homepageKey);
+      final resolvedHomepage = (storedHomepage?.isNotEmpty ?? false)
+          ? storedHomepage!
+          : defaultHomepageUrl;
+      final resolvedHideAppBar = readBool(hideAppBarKey, defaultValue: false);
+      final resolvedUseModernUserAgent =
+          readBool(useModernUserAgentKey, defaultValue: false);
+      final resolvedEnableGitFetch =
+          readBool(enableGitFetchKey, defaultValue: false);
+      final resolvedPrivateBrowsing =
+          readBool(privateBrowsingKey, defaultValue: false);
+      final resolvedAdBlocking = readBool(adBlockingKey, defaultValue: false);
+      final resolvedStrictMode = readBool(strictModeKey, defaultValue: false);
+      final resolvedPageFontFamily = readString(pageFontFamilyKey) ?? '';
+      final resolvedAiSearchSuggestionsEnabled =
+          readBool(aiSearchSuggestionsEnabledKey, defaultValue: false);
+      final resolvedAdvancedCacheEnabled =
+          readBool(advancedCacheEnabledKey, defaultValue: false);
+      final resolvedAmbientToolbarEnabled =
+          readBool(ambientToolbarEnabledKey, defaultValue: false);
+      final themeString = readString(themeModeKey);
       setState(() {
-        final storedHomepage = prefs.getString(homepageKey);
-        homepage = (storedHomepage == null || storedHomepage.isEmpty)
-            ? defaultHomepageUrl
-            : storedHomepage;
-        hideAppBar = prefs.getBool(hideAppBarKey) ?? false;
-        useModernUserAgent = prefs.getBool(useModernUserAgentKey) ?? false;
-        enableGitFetch = prefs.getBool(enableGitFetchKey) ?? false;
-        privateBrowsing = prefs.getBool(privateBrowsingKey) ?? false;
-        adBlocking = prefs.getBool(adBlockingKey) ?? false;
-        strictMode = prefs.getBool(strictModeKey) ?? false;
-        pageFontFamily = prefs.getString(pageFontFamilyKey) ?? '';
-        aiSearchSuggestionsEnabled =
-            prefs.getBool(aiSearchSuggestionsEnabledKey) ?? false;
-        advancedCacheEnabled = prefs.getBool(advancedCacheEnabledKey) ?? false;
-        ambientToolbarEnabled =
-            prefs.getBool(ambientToolbarEnabledKey) ?? false;
-        final themeString = prefs.getString(themeModeKey);
-        if (themeString != null) {
-          themeMode = AppThemeMode.values.firstWhere(
-            (m) => m.name == themeString,
-            orElse: () => AppThemeMode.system,
-          );
-        }
+        homepage = resolvedHomepage;
+        hideAppBar = resolvedHideAppBar;
+        useModernUserAgent = resolvedUseModernUserAgent;
+        enableGitFetch = resolvedEnableGitFetch;
+        privateBrowsing = resolvedPrivateBrowsing;
+        adBlocking = resolvedAdBlocking;
+        strictMode = resolvedStrictMode;
+        pageFontFamily = resolvedPageFontFamily;
+        aiSearchSuggestionsEnabled = resolvedAiSearchSuggestionsEnabled;
+        advancedCacheEnabled = resolvedAdvancedCacheEnabled;
+        ambientToolbarEnabled = resolvedAmbientToolbarEnabled;
+        themeMode = themeString == null
+            ? AppThemeMode.system
+            : AppThemeMode.values.firstWhere(
+                (m) => m.name == themeString,
+                orElse: () => AppThemeMode.system,
+              );
         previewThemeMode = null;
         if (themeMode != AppThemeMode.adjust) {
           adjustedThemeMode = ThemeMode.system;

--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -372,39 +372,52 @@ class SettingsDialog extends HookWidget {
     final showFirebaseConfig = useState(false);
     final loadedFirebaseConfig =
         useRef<Map<String, String>>(<String, String>{});
+    final lastSettingsProfileId = useRef<String?>(null);
 
     useEffect(() {
+      var cancelled = false;
       Future<void> loadPreferences() async {
         final prefs = await SharedPreferences.getInstance();
-        final storedHomepage = prefs.getString(homepageKey);
-        final resolvedHomepage =
-            (storedHomepage == null || storedHomepage.isEmpty)
-                ? defaultHomepageUrl
-                : storedHomepage;
-        hideAppBar.value = prefs.getBool(hideAppBarKey) ?? false;
+        if (cancelled) return;
+        String scopedKey(String key) => profileManager.getScopedStorageKey(key);
+        bool readBool(String key, {required bool defaultValue}) =>
+            prefs.getBool(scopedKey(key)) ?? defaultValue;
+
+        String? readString(String key) => prefs.getString(scopedKey(key));
+
+        final storedHomepage = readString(homepageKey);
+        final resolvedHomepage = (storedHomepage?.isNotEmpty ?? false)
+            ? storedHomepage!
+            : defaultHomepageUrl;
+        hideAppBar.value = readBool(hideAppBarKey, defaultValue: false);
         useModernUserAgent.value =
-            prefs.getBool(useModernUserAgentKey) ?? false;
-        enableGitFetch.value = prefs.getBool(enableGitFetchKey) ?? false;
-        privateBrowsing.value = prefs.getBool(privateBrowsingKey) ?? false;
+            readBool(useModernUserAgentKey, defaultValue: false);
+        enableGitFetch.value = readBool(enableGitFetchKey, defaultValue: false);
+        privateBrowsing.value =
+            readBool(privateBrowsingKey, defaultValue: false);
         originalPrivateBrowsing.value = privateBrowsing.value;
-        adBlocking.value = prefs.getBool(adBlockingKey) ?? false;
-        strictMode.value = prefs.getBool(strictModeKey) ?? false;
+        adBlocking.value = readBool(adBlockingKey, defaultValue: false);
+        strictMode.value = readBool(strictModeKey, defaultValue: false);
         passwordManagerEnabled.value =
-            prefs.getBool(passwordManagerEnabledKey) ?? false;
-        reorderableTabs.value = prefs.getBool(reorderableTabsKey) ?? false;
+            readBool(passwordManagerEnabledKey, defaultValue: false);
+        reorderableTabs.value =
+            readBool(reorderableTabsKey, defaultValue: false);
         aiSearchSuggestionsEnabled.value =
-            prefs.getBool(aiSearchSuggestionsEnabledKey) ?? false;
+            readBool(aiSearchSuggestionsEnabledKey, defaultValue: false);
         advancedCacheEnabled.value =
-            prefs.getBool(advancedCacheEnabledKey) ?? false;
+            readBool(advancedCacheEnabledKey, defaultValue: false);
         ambientToolbarEnabled.value =
-            prefs.getBool(ambientToolbarEnabledKey) ?? false;
-        if (prefs.getString(themeModeKey) != null) {
-          selectedTheme.value = AppThemeMode.values.firstWhere(
-              (m) => m.name == prefs.getString(themeModeKey),
-              orElse: () => currentTheme ?? AppThemeMode.system);
-        }
+            readBool(ambientToolbarEnabledKey, defaultValue: false);
+        final themeString = readString(themeModeKey);
+        selectedTheme.value = themeString == null
+            ? (currentTheme ?? AppThemeMode.system)
+            : AppThemeMode.values.firstWhere(
+                (m) => m.name == themeString,
+                orElse: () => currentTheme ?? AppThemeMode.system,
+              );
 
         final firebaseConfig = await FirebaseConfigStore.loadSettingsConfig();
+        if (cancelled) return;
         firebaseApiKey.text = firebaseConfig[firebaseApiKeyPref] ?? '';
         firebaseAppId.text = firebaseConfig[firebaseAppIdPref] ?? '';
         firebaseSenderId.text = firebaseConfig[firebaseSenderIdPref] ?? '';
@@ -425,8 +438,20 @@ class SettingsDialog extends HookWidget {
             resolvedHomepage == defaultHomepageUrl ? '' : resolvedHomepage;
       }
 
-      loadPreferences();
-      return null;
+      void handleProfileChange() {
+        final current = profileManager.activeProfileId;
+        if (current == lastSettingsProfileId.value) return;
+        lastSettingsProfileId.value = current;
+        unawaited(loadPreferences());
+      }
+
+      lastSettingsProfileId.value = profileManager.activeProfileId;
+      profileManager.addListener(handleProfileChange);
+      unawaited(loadPreferences());
+      return () {
+        cancelled = true;
+        profileManager.removeListener(handleProfileChange);
+      };
     }, const []);
 
     if (homepage.value == null) {
@@ -996,6 +1021,8 @@ class SettingsDialog extends HookWidget {
               homepageToSave = processed;
             }
             final prefs = await SharedPreferences.getInstance();
+            String scopedKey(String key) =>
+                profileManager.getScopedStorageKey(key);
 
             // Check if Firebase config changed from loaded values.
             final oldApiKey =
@@ -1021,24 +1048,28 @@ class SettingsDialog extends HookWidget {
                 oldProjectId != newProjectId ||
                 oldStorageBucket != newStorageBucket;
 
-            await prefs.setString(homepageKey, homepageToSave);
-            await prefs.setBool(hideAppBarKey, hideAppBar.value);
+            await prefs.setString(scopedKey(homepageKey), homepageToSave);
+            await prefs.setBool(scopedKey(hideAppBarKey), hideAppBar.value);
             await prefs.setBool(
-                useModernUserAgentKey, useModernUserAgent.value);
-            await prefs.setBool(enableGitFetchKey, enableGitFetch.value);
-            await prefs.setBool(privateBrowsingKey, privateBrowsing.value);
-            await prefs.setBool(adBlockingKey, adBlocking.value);
-            await prefs.setBool(strictModeKey, strictMode.value);
+                scopedKey(useModernUserAgentKey), useModernUserAgent.value);
             await prefs.setBool(
-                passwordManagerEnabledKey, passwordManagerEnabled.value);
-            await prefs.setBool(reorderableTabsKey, reorderableTabs.value);
-            await prefs.setBool(aiSearchSuggestionsEnabledKey,
+                scopedKey(enableGitFetchKey), enableGitFetch.value);
+            await prefs.setBool(
+                scopedKey(privateBrowsingKey), privateBrowsing.value);
+            await prefs.setBool(scopedKey(adBlockingKey), adBlocking.value);
+            await prefs.setBool(scopedKey(strictModeKey), strictMode.value);
+            await prefs.setBool(scopedKey(passwordManagerEnabledKey),
+                passwordManagerEnabled.value);
+            await prefs.setBool(
+                scopedKey(reorderableTabsKey), reorderableTabs.value);
+            await prefs.setBool(scopedKey(aiSearchSuggestionsEnabledKey),
                 aiSearchSuggestionsEnabled.value);
             await prefs.setBool(
-                advancedCacheEnabledKey, advancedCacheEnabled.value);
-            await prefs.setBool(
-                ambientToolbarEnabledKey, ambientToolbarEnabled.value);
-            await prefs.setString(themeModeKey, selectedTheme.value.name);
+                scopedKey(advancedCacheEnabledKey), advancedCacheEnabled.value);
+            await prefs.setBool(scopedKey(ambientToolbarEnabledKey),
+                ambientToolbarEnabled.value);
+            await prefs.setString(
+                scopedKey(themeModeKey), selectedTheme.value.name);
 
             try {
               await FirebaseConfigStore.saveSettingsConfig(
@@ -1107,10 +1138,15 @@ class _ProfileManagerDialogState extends State<_ProfileManagerDialog> {
     final theme = Theme.of(context);
 
     return AlertDialog(
+      alignment: Alignment.centerRight,
+      insetPadding: const EdgeInsets.fromLTRB(24, 24, 16, 24),
       backgroundColor: widget.ambientEnabled
           ? theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.9)
           : null,
-      title: const Text('Manage Profiles'),
+      title: Text(
+        'Manage Profiles',
+        style: theme.textTheme.titleSmall?.copyWith(fontSize: 15),
+      ),
       content: SizedBox(
         width: 300,
         child: Theme(
@@ -1231,7 +1267,12 @@ class _ProfileManagerDialogState extends State<_ProfileManagerDialog> {
         data: dialogTheme,
         child: StatefulBuilder(
           builder: (context, setStateDialog) => AlertDialog(
-            title: const Text('Create Profile'),
+            alignment: Alignment.centerRight,
+            insetPadding: const EdgeInsets.fromLTRB(24, 24, 16, 24),
+            title: Text(
+              'Create Profile',
+              style: theme.textTheme.titleSmall?.copyWith(fontSize: 15),
+            ),
             content: Column(
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -1338,7 +1379,13 @@ class _ProfileManagerDialogState extends State<_ProfileManagerDialog> {
       builder: (context) => Theme(
         data: dialogTheme,
         child: AlertDialog(
-          title: Text('Erase ${profile.name}?'),
+          alignment: Alignment.centerRight,
+          insetPadding: const EdgeInsets.fromLTRB(24, 24, 16, 24),
+          title: Text(
+            'Erase ${profile.name}?',
+            style:
+                Theme.of(context).textTheme.titleSmall?.copyWith(fontSize: 15),
+          ),
           content: Text(
             'All browsing data for this profile will be lost.',
             style: Theme.of(context).textTheme.bodySmall,
@@ -2582,7 +2629,8 @@ class _BrowserPageState extends State<BrowserPage>
 
   Future<void> _loadFontOverrides() async {
     final prefs = await SharedPreferences.getInstance();
-    final rawOverrides = prefs.getString(pageFontOverridesKey);
+    final rawOverrides = prefs
+        .getString(profileManager.getScopedStorageKey(pageFontOverridesKey));
     if (rawOverrides == null || rawOverrides.trim().isEmpty) {
       return;
     }
@@ -2604,7 +2652,10 @@ class _BrowserPageState extends State<BrowserPage>
 
   Future<void> _persistFontOverrides() async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(pageFontOverridesKey, jsonEncode(_siteFontFamilies));
+    await prefs.setString(
+      profileManager.getScopedStorageKey(pageFontOverridesKey),
+      jsonEncode(_siteFontFamilies),
+    );
   }
 
   Map<String, dynamic>? _parseThemeProbe(dynamic result) {
@@ -2704,8 +2755,10 @@ class _BrowserPageState extends State<BrowserPage>
     if (widget.privateBrowsing) return;
 
     final prefs = await SharedPreferences.getInstance();
-    final passwordManagerEnabled =
-        prefs.getBool(passwordManagerEnabledKey) ?? false;
+    final passwordManagerEnabled = prefs.getBool(
+          profileManager.getScopedStorageKey(passwordManagerEnabledKey),
+        ) ??
+        false;
     if (!passwordManagerEnabled) return;
 
     try {
@@ -3500,9 +3553,13 @@ class _BrowserPageState extends State<BrowserPage>
 
   Future<void> _loadReorderableTabs() async {
     final prefs = await SharedPreferences.getInstance();
+    final resolved = prefs.getBool(
+          profileManager.getScopedStorageKey(reorderableTabsKey),
+        ) ??
+        false;
     if (!mounted) return;
     setState(() {
-      _reorderableTabs = prefs.getBool(reorderableTabsKey) ?? false;
+      _reorderableTabs = resolved;
     });
   }
 
@@ -3630,11 +3687,15 @@ class _BrowserPageState extends State<BrowserPage>
 
   void _onProfileChanged() {
     if (!mounted) return;
-    if (widget.privateBrowsing) return;
     bookmarkManager.clear();
     _history.clear();
+    _navigationCacheIndex.clear();
+    _siteFontFamilies.clear();
     _loadBookmarks();
     _loadHistory();
+    unawaited(_loadReorderableTabs());
+    unawaited(_loadFontOverrides());
+    unawaited(_loadNavigationCacheIndex());
     setState(() {});
   }
 
@@ -3664,7 +3725,9 @@ class _BrowserPageState extends State<BrowserPage>
   Future<void> _loadNavigationCacheIndex() async {
     if (widget.privateBrowsing) return;
     final prefs = await SharedPreferences.getInstance();
-    final raw = prefs.getString(navigationCacheIndexKey);
+    final raw = prefs.getString(
+      profileManager.getScopedStorageKey(navigationCacheIndexKey),
+    );
     if (raw == null || raw.trim().isEmpty) return;
     try {
       final decoded = jsonDecode(raw);
@@ -3688,7 +3751,7 @@ class _BrowserPageState extends State<BrowserPage>
     if (widget.privateBrowsing) return;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(
-      navigationCacheIndexKey,
+      profileManager.getScopedStorageKey(navigationCacheIndexKey),
       jsonEncode(_navigationCacheIndex),
     );
   }
@@ -4062,6 +4125,8 @@ class _BrowserPageState extends State<BrowserPage>
       }
       _navigationCacheIndex.clear();
       final prefs = await SharedPreferences.getInstance();
+      await prefs
+          .remove(profileManager.getScopedStorageKey(navigationCacheIndexKey));
       await prefs.remove(navigationCacheIndexKey);
     } catch (e, s) {
       logger.w('Failed to clear caches', error: e, stackTrace: s);
@@ -4333,7 +4398,10 @@ class _BrowserPageState extends State<BrowserPage>
       }
     } else {
       if (result.fontFamily == _pageFontFamily) return;
-      await prefs.setString(pageFontFamilyKey, result.fontFamily);
+      await prefs.setString(
+        profileManager.getScopedStorageKey(pageFontFamilyKey),
+        result.fontFamily,
+      );
       setState(() {
         _pageFontFamily = result.fontFamily;
       });
@@ -5407,8 +5475,10 @@ class _BrowserPageState extends State<BrowserPage>
       tab.webViewController!.addJavaScriptChannel('LoginDetector',
           onMessageReceived: (JavaScriptMessage message) async {
         final prefs = await SharedPreferences.getInstance();
-        final passwordManagerEnabled =
-            prefs.getBool(passwordManagerEnabledKey) ?? false;
+        final passwordManagerEnabled = prefs.getBool(
+              profileManager.getScopedStorageKey(passwordManagerEnabledKey),
+            ) ??
+            false;
         if (!passwordManagerEnabled) return;
 
         try {

--- a/test/ux/settings_dialog_test.dart
+++ b/test/ux/settings_dialog_test.dart
@@ -6,6 +6,7 @@
 
 import 'package:browser/constants.dart';
 import 'package:browser/features/theme_utils.dart';
+import 'package:browser/main.dart' show profileManager;
 import 'package:browser/ux/browser_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -66,14 +67,25 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('SettingsDialog', () {
+    Future<void> initProfileManager() async {
+      profileManager.resetForTesting();
+      await profileManager.initialize();
+    }
+
     testWidgets('loads persisted switch and theme values',
         (WidgetTester tester) async {
-      SharedPreferences.setMockInitialValues({
-        useModernUserAgentKey: true,
-        enableGitFetchKey: true,
-        aiSearchSuggestionsEnabledKey: true,
-        themeModeKey: AppThemeMode.dark.name,
-      });
+      SharedPreferences.setMockInitialValues({});
+      await initProfileManager();
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(
+          profileManager.getScopedStorageKey(useModernUserAgentKey), true);
+      await prefs.setBool(
+          profileManager.getScopedStorageKey(enableGitFetchKey), true);
+      await prefs.setBool(
+          profileManager.getScopedStorageKey(aiSearchSuggestionsEnabledKey),
+          true);
+      await prefs.setString(profileManager.getScopedStorageKey(themeModeKey),
+          AppThemeMode.dark.name);
 
       await _openSettingsDialog(
         tester,
@@ -89,13 +101,80 @@ void main() {
       expect(tester.widget<ChoiceChip>(darkChip).selected, isTrue);
     });
 
-    testWidgets('save persists toggles and theme preview callback',
+    testWidgets('new profiles start with default (off) settings',
         (WidgetTester tester) async {
       SharedPreferences.setMockInitialValues({
-        useModernUserAgentKey: false,
-        aiSearchSuggestionsEnabledKey: false,
-        themeModeKey: AppThemeMode.system.name,
+        // Legacy unscoped prefs (pre-profile settings) that should migrate
+        // only into the default profile.
+        useModernUserAgentKey: true,
       });
+      await initProfileManager();
+
+      await _openSettingsDialog(
+        tester,
+        _dialogHost(aiAvailable: false),
+      );
+      expect(_readSwitchTile(tester, 'Legacy User Agent').value, isTrue);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      final workProfile = await profileManager.createProfile('Work');
+      await profileManager.switchProfile(workProfile.id);
+
+      await _openSettingsDialog(
+        tester,
+        _dialogHost(aiAvailable: false),
+      );
+      expect(_readSwitchTile(tester, 'Legacy User Agent').value, isFalse);
+    });
+
+    testWidgets('switching profiles refreshes toggles in the same dialog',
+        (WidgetTester tester) async {
+      FlutterSecureStorage.setMockInitialValues({});
+      SharedPreferences.setMockInitialValues({});
+      await initProfileManager();
+
+      final workProfile = await profileManager.createProfile('Work');
+      final prefs = await SharedPreferences.getInstance();
+
+      await prefs.setBool(
+          profileManager.getScopedStorageKey(useModernUserAgentKey), false);
+      await prefs.setString(profileManager.getScopedStorageKey(themeModeKey),
+          AppThemeMode.light.name);
+      await profileManager.switchProfile(workProfile.id);
+      await prefs.setBool(
+          profileManager.getScopedStorageKey(useModernUserAgentKey), true);
+      await prefs.setString(profileManager.getScopedStorageKey(themeModeKey),
+          AppThemeMode.dark.name);
+      await profileManager.switchProfile('default');
+
+      await _openSettingsDialog(
+        tester,
+        _dialogHost(aiAvailable: false),
+      );
+      expect(_readSwitchTile(tester, 'Legacy User Agent').value, isFalse);
+      final lightChip = find.widgetWithText(ChoiceChip, 'light');
+      expect(tester.widget<ChoiceChip>(lightChip).selected, isTrue);
+
+      await profileManager.switchProfile(workProfile.id);
+      await tester.pumpAndSettle();
+      expect(_readSwitchTile(tester, 'Legacy User Agent').value, isTrue);
+      final darkChip = find.widgetWithText(ChoiceChip, 'dark');
+      expect(tester.widget<ChoiceChip>(darkChip).selected, isTrue);
+    });
+
+    testWidgets('save persists toggles and theme preview callback',
+        (WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues({});
+      await initProfileManager();
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(
+          profileManager.getScopedStorageKey(useModernUserAgentKey), false);
+      await prefs.setBool(
+          profileManager.getScopedStorageKey(aiSearchSuggestionsEnabledKey),
+          false);
+      await prefs.setString(profileManager.getScopedStorageKey(themeModeKey),
+          AppThemeMode.system.name);
 
       final previewModes = <AppThemeMode>[];
 
@@ -139,18 +218,29 @@ void main() {
       await tester.tap(find.text('Save'));
       await tester.pumpAndSettle();
 
-      final prefs = await SharedPreferences.getInstance();
-      expect(prefs.getBool(useModernUserAgentKey), isTrue);
-      expect(prefs.getBool(aiSearchSuggestionsEnabledKey), isTrue);
-      expect(prefs.getString(themeModeKey), AppThemeMode.dark.name);
+      final prefsAfter = await SharedPreferences.getInstance();
+      expect(
+          prefsAfter.getBool(
+              profileManager.getScopedStorageKey(useModernUserAgentKey)),
+          isTrue);
+      expect(
+          prefsAfter.getBool(profileManager
+              .getScopedStorageKey(aiSearchSuggestionsEnabledKey)),
+          isTrue);
+      expect(
+          prefsAfter
+              .getString(profileManager.getScopedStorageKey(themeModeKey)),
+          AppThemeMode.dark.name);
       expect(previewModes, contains(AppThemeMode.dark));
     });
 
     testWidgets('cancel does not persist modified values',
         (WidgetTester tester) async {
-      SharedPreferences.setMockInitialValues({
-        useModernUserAgentKey: false,
-      });
+      SharedPreferences.setMockInitialValues({});
+      await initProfileManager();
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(
+          profileManager.getScopedStorageKey(useModernUserAgentKey), false);
 
       var settingsChangedCount = 0;
       await _openSettingsDialog(
@@ -166,14 +256,18 @@ void main() {
       await tester.tap(find.text('Cancel'));
       await tester.pumpAndSettle();
 
-      final prefs = await SharedPreferences.getInstance();
-      expect(prefs.getBool(useModernUserAgentKey), isFalse);
+      final prefsAfter = await SharedPreferences.getInstance();
+      expect(
+          prefsAfter.getBool(
+              profileManager.getScopedStorageKey(useModernUserAgentKey)),
+          isFalse);
       expect(settingsChangedCount, 0);
     });
 
     testWidgets('displays Firebase configuration fields',
         (WidgetTester tester) async {
       SharedPreferences.setMockInitialValues({});
+      await initProfileManager();
 
       await _openSettingsDialog(
         tester,
@@ -212,6 +306,7 @@ void main() {
         firebaseAppIdPref: 'test-app-id',
         firebaseProjectIdPref: 'test-project',
       });
+      await initProfileManager();
 
       await _openSettingsDialog(
         tester,
@@ -268,6 +363,7 @@ void main() {
         (WidgetTester tester) async {
       FlutterSecureStorage.setMockInitialValues({});
       SharedPreferences.setMockInitialValues({});
+      await initProfileManager();
 
       await _openSettingsDialog(
         tester,


### PR DESCRIPTION
Hmm, I want to make sure I don't miss anything. Let's keep things edged!

## Summary
- Scope all settings toggles/preferences by active profile (isolated per profile)
- Migrate legacy unscoped prefs once into `default` only
- Refresh Settings UI when switching profiles
- Align profile modals (manage/create/erase) with Settings modal layout
- Extend widget tests for profile-scoped settings

## Impact
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [x] Refactor / cleanup
- [ ] Documentation
- [x] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Resolves #423
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers
- Expected behavior: each profile starts with toggles OFF unless explicitly saved for that profile.

## Verification Steps
- `flutter test test/ux/settings_dialog_test.dart test/ux/profile_manager_test.dart`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Settings are now profile-specific—each profile maintains independent preferences
  * Legacy settings automatically migrate to your default profile on first use
  * Settings refresh automatically when you switch profiles

* **Improvements**
  * Enhanced profile management dialogs with improved layout and styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->