### PR TITLE
feat[ui] :: enhance URL autocomplete with deletion, positioning, and close button

### DIFF
--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -1739,6 +1739,16 @@ class _BrowserPageState extends State<BrowserPage>
     'file',
   };
 
+  static const int _urlAutocompleteRecentInteractionWindowMs = 250;
+  static const int _urlAutocompleteShowCloseButtonThreshold = 5;
+  static const double _urlAutocompleteOverlayOffset = 6;
+  static const double _urlAutocompleteOverlayMargin = 12;
+  static const double _urlAutocompleteOverlayMinWidth = 0;
+  static const double _urlAutocompleteOverlayMaxWidthCap = 720;
+  static const double _urlAutocompleteOverlayMinHeight = 0;
+  static const double _urlAutocompleteOverlayMaxHeightCap = 240;
+  static const double _urlAutocompleteOverlayFlipThreshold = 160;
+
   late TabController tabController;
   final List<TabData> tabs = [];
   final bookmarkManager = BookmarkManager();
@@ -1755,6 +1765,10 @@ class _BrowserPageState extends State<BrowserPage>
   List<String> _urlAutocompleteOptions = const <String>[];
   double? _urlAutocompleteTargetWidth;
   bool _urlAutocompleteOverlayUpdateQueued = false;
+  int _lastUrlAutocompleteOverlayPointerDownMs = 0;
+  double _urlAutocompleteOverlayMaxWidth = _urlAutocompleteOverlayMaxWidthCap;
+  double _urlAutocompleteOverlayMaxHeight = _urlAutocompleteOverlayMaxHeightCap;
+  bool _urlAutocompleteShowAbove = false;
   final Set<String> _downloadableExtensions = {
     'dmg',
     'zip',
@@ -2157,6 +2171,15 @@ class _BrowserPageState extends State<BrowserPage>
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted || tab.isClosed) return;
         if (tab.urlFocusNode.hasFocus) return;
+        final nowMs = DateTime.now().millisecondsSinceEpoch;
+        final interactedWithOverlayRecently =
+            _urlAutocompleteOverlayEntry != null &&
+                nowMs - _lastUrlAutocompleteOverlayPointerDownMs <
+                    _urlAutocompleteRecentInteractionWindowMs;
+        if (interactedWithOverlayRecently) {
+          tab.urlFocusNode.requestFocus();
+          return;
+        }
         _removeUrlAutocompleteOverlay();
       });
       _syncPagePointerEvents(tab);
@@ -2177,6 +2200,36 @@ class _BrowserPageState extends State<BrowserPage>
     activeTab.urlFocusNode.unfocus();
     _removeUrlAutocompleteOverlay();
     _loadUrl(value);
+  }
+
+  Future<void> _persistHistoryAfterSuggestionDelete() async {
+    final historyKey = profileManager.historyKey;
+    final prefs = await SharedPreferences.getInstance();
+    if (profileManager.historyKey != historyKey) return;
+    await prefs.setString(historyKey, jsonEncode(_history));
+  }
+
+  String _normalizeHistoryKey(String value) => value.trim().toLowerCase();
+
+  void _removeUrlAutocompleteSuggestion(String value) {
+    final normalized = _normalizeHistoryKey(value);
+    _history.removeWhere((entry) => _normalizeHistoryKey(entry) == normalized);
+    for (final tab in tabs) {
+      tab.history
+          .removeWhere((entry) => _normalizeHistoryKey(entry) == normalized);
+    }
+
+    _urlAutocompleteOptions =
+        _historyUrlSuggestions(activeTab.urlController.text)
+            .toList(growable: false);
+
+    unawaited(_persistHistoryAfterSuggestionDelete());
+
+    if (_urlAutocompleteOptions.isEmpty) {
+      _removeUrlAutocompleteOverlay();
+      return;
+    }
+    _urlAutocompleteOverlayEntry?.markNeedsBuild();
   }
 
   void _removeUrlAutocompleteOverlay({bool updatePointerEvents = true}) {
@@ -2212,6 +2265,31 @@ class _BrowserPageState extends State<BrowserPage>
           _urlAutocompleteTargetKey.currentContext?.findRenderObject();
       if (targetBox is RenderBox && targetBox.hasSize) {
         _urlAutocompleteTargetWidth = targetBox.size.width;
+        final overlayBox =
+            Overlay.of(context, rootOverlay: true).context.findRenderObject();
+        if (overlayBox is RenderBox && overlayBox.hasSize) {
+          final overlayTopLeft = overlayBox.localToGlobal(Offset.zero);
+          final targetTopLeft = targetBox.localToGlobal(Offset.zero);
+          final dx = targetTopLeft.dx - overlayTopLeft.dx;
+          final dy = targetTopLeft.dy - overlayTopLeft.dy;
+          const minMargin = _urlAutocompleteOverlayMargin;
+          final spaceBelow = overlayBox.size.height -
+              (dy + targetBox.size.height + _urlAutocompleteOverlayOffset) -
+              minMargin;
+          final spaceAbove = dy - minMargin;
+          final showAbove = spaceBelow < _urlAutocompleteOverlayFlipThreshold &&
+              spaceAbove > spaceBelow;
+          _urlAutocompleteShowAbove = showAbove;
+          _urlAutocompleteOverlayMaxWidth =
+              (overlayBox.size.width - dx - minMargin).clamp(
+                  _urlAutocompleteOverlayMinWidth,
+                  _urlAutocompleteOverlayMaxWidthCap);
+          final maxHeight = (showAbove ? spaceAbove : spaceBelow)
+              .clamp(_urlAutocompleteOverlayMinHeight,
+                  _urlAutocompleteOverlayMaxHeightCap)
+              .toDouble();
+          _urlAutocompleteOverlayMaxHeight = maxHeight;
+        }
       }
       final options = _historyUrlSuggestions(tab.urlController.text)
           .toList(growable: false);
@@ -2230,8 +2308,9 @@ class _BrowserPageState extends State<BrowserPage>
             if (optionList.isEmpty) {
               return const SizedBox.shrink();
             }
+            final maxWidth = _urlAutocompleteOverlayMaxWidth;
             final minWidth = (_urlAutocompleteTargetWidth ?? 300.0)
-                .clamp(300.0, 720.0)
+                .clamp(_urlAutocompleteOverlayMinWidth, maxWidth)
                 .toDouble();
             return Stack(
               children: [
@@ -2244,49 +2323,123 @@ class _BrowserPageState extends State<BrowserPage>
                 CompositedTransformFollower(
                   link: _urlAutocompleteLink,
                   showWhenUnlinked: false,
-                  targetAnchor: Alignment.bottomLeft,
-                  followerAnchor: Alignment.topLeft,
-                  offset: const Offset(0, 6),
-                  child: Material(
-                    elevation: 6,
-                    color: theme.colorScheme.surfaceContainerHigh,
-                    borderRadius: BorderRadius.circular(12),
-                    child: ConstrainedBox(
-                      constraints: BoxConstraints(
-                        maxHeight: 240,
-                        minWidth: minWidth,
-                        maxWidth: 720,
-                      ),
-                      child: ListView.builder(
-                        padding: const EdgeInsets.symmetric(vertical: 6),
-                        shrinkWrap: true,
-                        itemCount: optionList.length,
-                        itemBuilder: (context, index) {
-                          final option = optionList[index];
-                          return InkWell(
-                            onTapDown: (_) =>
-                                _selectUrlAutocompleteOption(option),
-                            onTap: () {},
-                            hoverColor: Colors.transparent,
-                            splashColor: Colors.transparent,
-                            highlightColor: Colors.transparent,
-                            focusColor: Colors.transparent,
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 12,
-                                vertical: 8,
-                              ),
-                              child: Text(
-                                option,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: theme.textTheme.bodySmall?.copyWith(
-                                  fontSize: 12,
+                  targetAnchor: _urlAutocompleteShowAbove
+                      ? Alignment.topLeft
+                      : Alignment.bottomLeft,
+                  followerAnchor: _urlAutocompleteShowAbove
+                      ? Alignment.bottomLeft
+                      : Alignment.topLeft,
+                  offset: _urlAutocompleteShowAbove
+                      ? const Offset(0, -_urlAutocompleteOverlayOffset)
+                      : const Offset(0, _urlAutocompleteOverlayOffset),
+                  child: Listener(
+                    behavior: HitTestBehavior.opaque,
+                    onPointerDown: (_) {
+                      _lastUrlAutocompleteOverlayPointerDownMs =
+                          DateTime.now().millisecondsSinceEpoch;
+                    },
+                    child: Material(
+                      elevation: 6,
+                      color: theme.colorScheme.surfaceContainerHigh,
+                      borderRadius: BorderRadius.circular(12),
+                      child: ConstrainedBox(
+                        constraints: BoxConstraints(
+                          maxHeight: _urlAutocompleteOverlayMaxHeight,
+                          minWidth: minWidth,
+                          maxWidth: maxWidth,
+                        ),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            if (optionList.length >=
+                                _urlAutocompleteShowCloseButtonThreshold)
+                              SizedBox(
+                                height: 32,
+                                child: Align(
+                                  alignment: Alignment.centerRight,
+                                  child: IconButton(
+                                    iconSize: 18,
+                                    splashRadius: 18,
+                                    onPressed: _removeUrlAutocompleteOverlay,
+                                    icon: const Icon(
+                                      Icons.close,
+                                      semanticLabel: 'Close suggestions',
+                                    ),
+                                  ),
                                 ),
                               ),
+                            Flexible(
+                              child: ListView.builder(
+                                padding:
+                                    const EdgeInsets.symmetric(vertical: 6),
+                                shrinkWrap: true,
+                                itemCount: optionList.length,
+                                itemBuilder: (context, index) {
+                                  final option = optionList[index];
+                                  return Padding(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 12,
+                                      vertical: 4,
+                                    ),
+                                    child: Row(
+                                      children: [
+                                        Expanded(
+                                          child: InkWell(
+                                            onTap: () =>
+                                                _selectUrlAutocompleteOption(
+                                                    option),
+                                            hoverColor: Colors.transparent,
+                                            splashColor: Colors.transparent,
+                                            highlightColor: Colors.transparent,
+                                            focusColor: Colors.transparent,
+                                            child: Padding(
+                                              padding:
+                                                  const EdgeInsets.symmetric(
+                                                vertical: 4,
+                                              ),
+                                              child: Text(
+                                                option,
+                                                maxLines: 1,
+                                                overflow: TextOverflow.ellipsis,
+                                                style: theme.textTheme.bodySmall
+                                                    ?.copyWith(
+                                                  fontSize: 12,
+                                                ),
+                                              ),
+                                            ),
+                                          ),
+                                        ),
+                                        const SizedBox(width: 8),
+                                        Semantics(
+                                          button: true,
+                                          label: 'Remove from history',
+                                          child: IconButton(
+                                            iconSize: 18,
+                                            splashRadius: 18,
+                                            padding: EdgeInsets.zero,
+                                            constraints:
+                                                const BoxConstraints.tightFor(
+                                              width: 32,
+                                              height: 32,
+                                            ),
+                                            onPressed: () =>
+                                                _removeUrlAutocompleteSuggestion(
+                                                    option),
+                                            icon: Icon(
+                                              Icons.remove_circle_outline,
+                                              color: theme
+                                                  .colorScheme.onSurfaceVariant,
+                                            ),
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  );
+                                },
+                              ),
                             ),
-                          );
-                        },
+                          ],
+                        ),
                       ),
                     ),
                   ),


### PR DESCRIPTION
When switching between non-fullscreen and fullscreen (or resizing the window), the URL autocomplete suggestions dropdown
  may briefly flicker because it recalculates its size and position across frames. This looks like a small jump/repaint to
  the user, even though the final size/position is correct. It’s cosmetic and not blocking, so we’re intentionally deferring
  it to keep the current PR small and focused.

## Summary
- Ensure per-suggestion remove only deletes that entry from the current profile’s browsing history
- Prevent remove clicks from triggering the parent suggestion tap (no navigation / tab-close side effects)
- Make the suggestions dropdown fit within the current window and flip above the URL bar when needed

## Impact
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Resolves #426
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers
- Ran Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 93.0.0 (98.0.0 available)
  analyzer 10.0.1 (12.0.0 available)
  build_config 1.2.0 (1.3.0 available)
  build_runner 2.11.1 (2.13.0 available)
  dart_style 3.1.6 (3.1.8 available)
  device_info_plus 11.5.0 (12.3.0 available)
  flutter_markdown 0.7.7+1 (discontinued replaced by flutter_markdown_plus)
  hooks 1.0.1 (1.0.2 available)
  logger 2.6.2 (2.7.0 available)
  markdown 7.3.0 (7.3.1 available)
! matcher 0.12.19 (overridden)
! material_color_utilities 0.13.0 (overridden)
  meta 1.17.0 (1.18.2 available)
  native_toolchain_c 0.17.4 (0.17.6 available)
  package_info_plus 8.3.1 (9.0.0 available)
  passkeys 2.17.4 (2.18.0 available)
  passkeys_android 2.11.0 (2.12.0 available)
  passkeys_doctor 1.2.0 (1.3.0 available)
  source_gen 4.2.0 (4.2.1 available)
! test_api 0.7.10 (overridden) (0.7.11 available)
  vector_math 2.2.0 (2.3.0 available)
  webview_flutter_wkwebview 3.23.8 (3.24.1 available)
  win32 5.15.0 (6.0.0 available)
  win32_registry 2.1.0 (3.0.2 available)
Got dependencies!
1 package is discontinued.
21 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
00:00 +0: loading /Users/niladri/browser/test/ux/profile_manager_test.dart
00:00 +0: ProfileManager creates default profile on first initialize
00:00 +1: ProfileManager creates new profile with custom name
00:00 +2: ProfileManager creates new profile with selected color
00:00 +3: ProfileManager switchProfile changes active profile
00:00 +4: ProfileManager switchProfile does nothing for same profile
00:00 +5: ProfileManager deleteProfile removes profile
00:00 +6: ProfileManager deleteProfile cannot delete default profile
00:00 +7: ProfileManager deleteProfile switches to default if deleting active
00:00 +8: ProfileManager profile storage keys are scoped by active profile
00:00 +9: ProfileManager profile storage keys change with active profile
00:00 +10: ProfileManager notifies listeners on profile creation and switch
00:00 +11: ProfileManager persists active profile
00:00 +12: UserProfile model creates profile from JSON
00:00 +13: UserProfile model converts profile to JSON
00:00 +14: UserProfile model available colors list is not empty
00:00 +15: UserProfile model profile equality based on id
00:00 +16: Profile Manager Dialog UI displays profile section in Settings
00:00 +17: All tests passed!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * URL autocomplete overlay now intelligently positions above or below the field based on available screen space
  * Autocomplete suggestions list dynamically adjusts width and height to fit your display
  * Added per-item delete button to remove suggestions from history and persist that change across tabs
  * Close (“X”) header appears when many suggestions are shown

* **Bug Fixes**
  * Improved focus handling to avoid dismissing the overlay during short user interactions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->