### PR TITLE
feat[version] :: enhance version bump with structured release notes and workflow dispatch

### DIFF
--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -156,10 +156,10 @@ runs:
       run: |
         VERSION=${{ steps.version.outputs.version }}
         if git ls-remote --tags --exit-code origin "${TAG_PREFIX}-${VERSION}"; then
-        echo "Tag ${TAG_PREFIX}-${VERSION} already exists on remote. Skipping tag creation."
+          echo "Tag ${TAG_PREFIX}-${VERSION} already exists on remote. Skipping tag creation."
         else
-        git tag "${TAG_PREFIX}-${VERSION}"
-        git push origin "${TAG_PREFIX}-${VERSION}"
+          git tag "${TAG_PREFIX}-${VERSION}"
+          git push origin "${TAG_PREFIX}-${VERSION}"
         fi
 
     - name: Create release if not exists
@@ -172,48 +172,50 @@ runs:
         PR_NUMBER: ${{ inputs.pr-number }}
       run: |
         VERSION=${{ steps.version.outputs.version }}
-        if gh release view "${TAG_PREFIX}-${VERSION}" &>/dev/null; then
-        echo "Release for tag ${TAG_PREFIX}-${VERSION} already exists. Skipping release creation."
+        TAG="${TAG_PREFIX}-${VERSION}"
+
+        if gh release view "${TAG}" &>/dev/null; then
+          echo "Release for tag ${TAG} already exists. Skipping release creation."
         else
-        PR_TITLE=$(gh pr view "$PR_NUMBER" --json title -q '.title')
-        PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q '.body')
+          PR_TITLE=$(gh pr view "$PR_NUMBER" --json title -q '.title')
+          PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q '.body')
 
-        extract_section() {
-          local heading="$1"
-          # Print content under a "## <heading>" section until the next "## " heading.
-          # Be robust to heading lines with extra spacing/trailing whitespace.
-          echo "$PR_BODY" | awk -v heading="$heading" '
-            function normalize(line) {
-              sub(/^[ \t\r\n]+/, "", line)
-              sub(/[ \t\r\n]+$/, "", line)
-              gsub(/[ \t]+/, " ", line)
-              return line
-            }
-            BEGIN { h = "## " heading }
-            normalize($0) == h { p=1; next }
-            /^##[ \t]/ { if(p){ exit } }
-            p { print }
-          '
-        }
+          extract_section() {
+            local heading="$1"
+            # Print content under a "## <heading>" section until the next "## " heading.
+            # Be robust to heading lines with extra spacing/trailing whitespace.
+            echo "$PR_BODY" | awk -v heading="$heading" '
+              function normalize(line) {
+                sub(/^[ \t\r\n]+/, "", line)
+                sub(/[ \t\r\n]+$/, "", line)
+                gsub(/[ \t]+/, " ", line)
+                return line
+              }
+              BEGIN { h = "## " heading }
+              normalize($0) == h { p=1; next }
+              /^##[ \t]/ { if(p){ exit } }
+              p { print }
+            '
+          }
 
-        # Prefer explicit release-note sections from the PR body (version bump PRs include these),
-        # otherwise fall back to the PR title.
-        SUMMARY_SECTION="$(extract_section "Summary" | sed '/^[[:space:]]*$/d')"
-        SUMMARY_SECTION="${SUMMARY_SECTION:-- ${PR_TITLE}}"
+          # Prefer explicit release-note sections from the PR body (version bump PRs include these),
+          # otherwise fall back to the PR title.
+          SUMMARY_SECTION="$(extract_section "Summary" | sed '/^[[:space:]]*$/d')"
+          SUMMARY_SECTION="${SUMMARY_SECTION:-- ${PR_TITLE}}"
 
-        WHATS_NEW_SECTION="$(extract_section "What's New" | sed '/^[[:space:]]*$/d')"
-        WHATS_NEW_CONTENT="${WHATS_NEW_SECTION:-${SUMMARY_SECTION}}"
+          WHATS_NEW_SECTION="$(extract_section "What's New" | sed '/^[[:space:]]*$/d')"
+          WHATS_NEW_CONTENT="${WHATS_NEW_SECTION:-${SUMMARY_SECTION}}"
 
-        BUG_FIX_SECTION="$(extract_section "Bug Fixes" | sed '/^[[:space:]]*$/d')"
-        if [[ -z "$BUG_FIX_SECTION" ]]; then
-          BUG_FIX_CONTENT="$SUMMARY_SECTION"
-        elif [[ "$BUG_FIX_SECTION" == "(none)" || "$BUG_FIX_SECTION" == "- (none)" ]]; then
-          BUG_FIX_CONTENT="- (none)"
-        else
-          BUG_FIX_CONTENT="$BUG_FIX_SECTION"
-        fi
+          BUG_FIX_SECTION="$(extract_section "Bug Fixes" | sed '/^[[:space:]]*$/d')"
+          if [[ -z "$BUG_FIX_SECTION" ]]; then
+            BUG_FIX_CONTENT="$SUMMARY_SECTION"
+          elif [[ "$BUG_FIX_SECTION" == "(none)" || "$BUG_FIX_SECTION" == "- (none)" ]]; then
+            BUG_FIX_CONTENT="- (none)"
+          else
+            BUG_FIX_CONTENT="$BUG_FIX_SECTION"
+          fi
 
-        NOTES=$(cat <<EOF
+          NOTES=$(cat <<EOF
         ## What's New
         ${WHATS_NEW_CONTENT}
 
@@ -229,7 +231,17 @@ runs:
 
         (auto bump)
         EOF
-        )
+          )
 
-        gh release create "${TAG_PREFIX}-${VERSION}" --title "Release ${VERSION}" --notes "${NOTES}"
+          gh release create "${TAG}" --title "Release ${VERSION}" --notes "${NOTES}"
+        fi
+
+        # Trigger DMG build/upload. Push-tag events created by GITHUB_TOKEN do not trigger workflows,
+        # so dispatch the release workflow explicitly.
+        if ! gh api -X POST \
+          "repos/${GITHUB_REPOSITORY}/actions/workflows/release.yml/dispatches" \
+          -f ref="main" \
+          -f inputs[tag]="${TAG}" \
+          >/dev/null; then
+          echo "Warning: failed to dispatch release workflow for ${TAG}"
         fi

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   bump-version:


### PR DESCRIPTION
[Notes for reviewers](https://github.com/bniladridas/browser/pull/440#notes-for-reviewers)
---

## Summary
- Prevent duplicate `## What's New` / `## Bug Fixes` headings in autogenerated GitHub releases by extracting structured sections from the merged PR body.
- Refine `Bug Fixes` fallback: missing section falls back to `Summary`, while explicit `(none)` / `- (none)` normalizes to `- (none)`.
- Generate version bump PR bodies with explicit headings (`## Summary`, `## What's New`, `## Bug Fixes`, `## Documentation`, `## Maintenance`) so section extraction is reliable.
- Auto-dispatch the `Release` workflow after tag/release creation so the DMG is built and uploaded without a manual trigger.

## Impact
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Resolves #439, #441
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

<a id="notes-for-reviewers"></a>
## Notes for reviewers
- Release generation uses `.github/actions/bump-version/action.yml` and `.github/workflows/release.yml`.
- Root cause: the workflow previously treated everything between `## Summary` and `## Impact` as “summary”; in the version-bump PR template this includes other headings like `## What's New` / `## Bug Fixes`, leading to duplicated headings in the release body.
- New behavior:
  - `What's New`: prefer the PR’s `## What's New` section content; otherwise fall back to `## Summary` (or PR title if `## Summary` is absent).
  - `Bug Fixes`: prefer the PR’s `## Bug Fixes` section content; if the section is absent fall back to `## Summary`; if the section is explicitly `(none)` / `- (none)` output `- (none)`.
  - Version bump PR creation now uses a multi-section Markdown body (via `--body-file`) so `extract_section` does not return empty for these headings.
  - The bump workflow now dispatches `.github/workflows/release.yml` with `inputs.tag` because tag pushes from `GITHUB_TOKEN` do not trigger workflows.
- `AGENTS.md` bump guidance still applies (PR description template + version-bump PR template); this change only ensures the auto-created bump PR body starts with compatible headings.

Mechanism:

- The bump action creates the tag + GitHub Release, then calls a workflow dispatch for `.github/workflows/release.yml` with `inputs.tag=desktop/app-X.Y.Z`.
- That workflow checks out that tag, builds, creates `browser.dmg`, and uploads it to the existing release.

Caveat:

- It will still only succeed if the `Release` workflow can build on `macos-latest` (Flutter build + signing/notarization step falls back to unsigned if cert isn’t available, but it still produces a DMG).

- Note: this only affects future releases; it does not retroactively update already-published release notes (for example `desktop/app-1.14.0`).

