### PR TITLE
feat[version] :: include `whats_new.json` generation to version bump workflow

### DIFF
--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -107,7 +107,7 @@ runs:
         normalize_whats_new_note() {
           local title="$1"
           title="$(printf '%s' "$title" | sed -E 's/[[:space:]]+\(#[0-9]+\)$//')"
-          title="$(printf '%s' "$title" | sed -E 's/^[a-z]+(\\[[^]]+\\])?[[:space:]]*::[[:space:]]*//')"
+          title="$(printf '%s' "$title" | sed -E 's/^[a-z]+([[][^]]+[]])?[[:space:]]*::[[:space:]]*//')"
           title="$(printf '%s' "$title" | sed -E 's/^[a-z]+:[[:space:]]*//')"
           title="$(printf '%s' "$title" | sed -E 's/[`*_]//g; s/[[:space:]]+/ /g; s/^ +| +$//g')"
 


### PR DESCRIPTION
## Summary
- Ensure the version bump automation writes a minimal user-facing note for the bumped version into assets/whats_new.json.
- Commit VERSION, pubspec.yaml, and assets/whats_new.json on the auto-generated version bump branch so bump PRs are merge-ready.
- Keep the bump PR body template unchanged.

## Impact
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Resolves #449
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers
- The bump action now normalizes the whats_new note from the merged PR title (strips conventional prefixes and ensures trailing punctuation).

## Review Process
- Self review

## Verification Steps
- `yamllint .github/actions/bump-version/action.yml .github/workflows/version-bump.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced version bump automation with improved "What's New" entry generation. Release notes now undergo normalization for consistent formatting, and changelog data is automatically maintained in a structured JSON format to ensure better release documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->