### PR TITLE
fix[scripts] :: cross-platform sed compatibility to pubspec version script

### DIFF
--- a/scripts/pubspec.sh
+++ b/scripts/pubspec.sh
@@ -7,11 +7,20 @@
 
 # Script to update pubspec.yaml version from VERSION file
 
+set -euo pipefail
+
 if [ ! -f VERSION ]; then
   echo "VERSION file not found"
   exit 1
 fi
 
 VERSION=$(cat VERSION)
-sed -i '' "s/^version: .*/version: $VERSION/" pubspec.yaml
+
+# macOS (BSD sed) requires `-i ''`, while GNU sed (Linux) supports `-i`.
+if sed --version >/dev/null 2>&1; then
+  sed -i "s/^version: .*/version: $VERSION/" pubspec.yaml
+else
+  sed -i '' "s/^version: .*/version: $VERSION/" pubspec.yaml
+fi
+
 echo "Updated pubspec.yaml version to $VERSION"


### PR DESCRIPTION
## Summary
- Make `scripts/pubspec.sh` update `pubspec.yaml` on both macOS (BSD sed) and Linux (GNU sed) so the version bump automation keeps versions in sync.

## Impact
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Resolves #452
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers
- The version bump workflow runs on ubuntu-latest; GNU sed needs `-i` while BSD sed needs `-i ''`.

## Review Process
- Self review

## Verification Steps
- `bash -n scripts/pubspec.sh`