### PR TITLE
fix[browser] :: improve macOS local file loading with WebKit-specific implementation

### DIFF
--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -20,6 +20,7 @@ import 'dart:io';
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 import 'package:webview_flutter/webview_flutter.dart';
+import 'package:webview_flutter_wkwebview/webview_flutter_wkwebview.dart';
 import 'package:http/http.dart' as http;
 import 'package:file_selector/file_selector.dart';
 import 'package:desktop_drop/desktop_drop.dart';
@@ -5810,7 +5811,7 @@ class _BrowserPageState extends State<BrowserPage>
       if (processedUrl.startsWith('file:///') ||
           processedUrl.startsWith('file://')) {
         final path = processedUrl.replaceFirst('file://', '');
-        await activeTab.webViewController?.loadFile(path);
+        await _loadLocalFile(path);
       } else {
         activeTab.webViewController?.loadRequest(Uri.parse(processedUrl));
       }
@@ -5820,6 +5821,26 @@ class _BrowserPageState extends State<BrowserPage>
             error: e, stackTrace: s);
       }
     }
+  }
+
+  Future<void> _loadLocalFile(String path) async {
+    final controller = activeTab.webViewController;
+    if (controller == null) return;
+
+    if (defaultTargetPlatform == TargetPlatform.macOS &&
+        controller.platform is WebKitWebViewController) {
+      final webKitController = controller.platform as WebKitWebViewController;
+      final parentPath = File(path).parent.path;
+      await webKitController.loadFileWithParams(
+        WebKitLoadFileParams(
+          absoluteFilePath: path,
+          readAccessPath: parentPath,
+        ),
+      );
+      return;
+    }
+
+    await controller.loadFile(path);
   }
 
   void _performTorrySearch(TabData tab, [String? text]) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1212,7 +1212,7 @@ packages:
     source: hosted
     version: "2.15.1"
   webview_flutter_wkwebview:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: webview_flutter_wkwebview
       sha256: d7219cfabc6f5fc2032e0fa980ec36d71f308a35a823395af1abc34d9a2ede83

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
 
   path_provider: ^2.1.5
   webview_flutter: ^4.8.0
+  webview_flutter_wkwebview: ^3.23.8
   file_selector: ^1.0.3
   desktop_drop: ^0.7.0
   logger: ^2.4.0


### PR DESCRIPTION
## Summary
- Restore sibling asset loading for local HTML files opened in the desktop browser
- Use WebKit file loading with directory read access on macOS for local file URLs
- Promote `webview_flutter_wkwebview` to a direct dependency for the platform-specific loader

## Impact
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Resolves #461
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers
- Review process: self-review.
- Verified with `flutter analyze` and a successful local `flutter build macos --debug`.

## Verification Steps
- Run `flutter analyze`
- Build the macOS app with `flutter build macos --debug`
- Drag a local HTML file that references a sibling image into the browser
- Confirm the page renders the image instead of a broken placeholder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced macOS platform support for loading local files through improved integration, ensuring more reliable file access and better handling of file:// protocol navigation. Users on Apple platforms will experience improved stability when accessing local file resources. File operations are now more robust and consistent across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->