### PR TITLE
fix[workflows] :: simplify issue similarity search using gh CLI instead of API

### DIFF
--- a/.github/workflows/issue-similarity.yml
+++ b/.github/workflows/issue-similarity.yml
@@ -51,18 +51,11 @@ jobs:
             exit 0
           fi
 
-          query="repo:${REPO} is:issue ${search_text}"
-          results=$(gh api search/issues \
-            -f q="$query" \
-            -f per_page=10 \
-            --jq '.items
-              | map(select(.number != '"$ISSUE_NUMBER"'))
-              | map({
-                  number: .number,
-                  title: .title,
-                  state: .state,
-                  url: .html_url
-                })')
+          results=$(gh search issues "${search_text}" \
+            --repo "$REPO" \
+            --limit 10 \
+            --json number,title,state,url \
+            --jq 'map(select(.number != '"$ISSUE_NUMBER"'))')
 
           if [ "$(printf '%s' "$results" | jq 'length')" -eq 0 ]; then
             echo "No similar issues found."


### PR DESCRIPTION
## Summary
- Replace the failing issue search API call in the issue similarity workflow
- Use `gh search issues` instead of the broken `gh api` search path
- Keep the workflow behavior the same while restoring successful issue triage suggestions

## Impact
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Resolves #464
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers
- Review process: self-review.
- Verified with `yamllint` and `actionlint` after the workflow update.

## Verification Steps
- Run `yamllint .github/workflows/issue-similarity.yml`
- Run `actionlint .github/workflows/issue-similarity.yml`
- Open or edit a test issue and confirm the workflow no longer fails at the search step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the GitHub Actions workflow for issue similarity detection with improved search efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->