### PR TITLE
fix[workflows] :: case-insensitive state filtering and empty results handling in issue similarity

### DIFF
--- a/.github/workflows/issue-similarity.yml
+++ b/.github/workflows/issue-similarity.yml
@@ -113,12 +113,17 @@ jobs:
             exit 0
           fi
 
-          open_items=$(jq -r '.[] | select(.state == "open") | "- #\(.number) - \(.title)"' \
+          open_items=$(jq -r '.[] | select((.state | ascii_downcase) == "open") | "- #\(.number) - \(.title)"' \
             "$results_file" \
             | head -n 3)
-          closed_items=$(jq -r '.[] | select(.state == "closed") | "- #\(.number) - \(.title)"' \
+          closed_items=$(jq -r '.[] | select((.state | ascii_downcase) == "closed") | "- #\(.number) - \(.title)"' \
             "$results_file" \
             | head -n 3)
+
+          if [ -z "$open_items" ] && [ -z "$closed_items" ]; then
+            echo "No displayable similar issues found."
+            exit 0
+          fi
 
           marker="<!-- issue-similarity-check -->"
           body_file=$(mktemp)


### PR DESCRIPTION
## Summary
- normalize issue state matching in the similarity workflow so GitHub issue states are classified correctly
- skip creating or updating the bot comment when no displayable similar issue lines are available
- keep the workflow validation path clean after the output quality fix

## Impact
- [ ] New feature
- [x] Bug fix
- [x] Build / CI
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Resolves #480
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers
- Review process: self-review and automated validation with yamllint and actionlint.
- This fixes the empty bot comment seen on issue #479 after the workflow started running successfully again.

## Verification Steps
- Run `yamllint .github/workflows/issue-similarity.yml`
- Run `actionlint .github/workflows/issue-similarity.yml`
- Open or edit a similar issue and confirm the bot comments only when at least one visible match line is available