### PR TITLE
feat[ci] :: integrate nightly build workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,34 @@
+---
+# SPDX-License-Identifier: MIT
+#
+# Copyright 2026 bniladridas. All rights reserved.
+# Use of this source code is governed by a MIT license that can be
+# found in the LICENSE file.
+
+name: Nightly Build
+
+on:
+  schedule:
+    - cron: '0 8 * * *'  # daily at 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  nightly:
+    uses: libnudget/nightly/.github/workflows/nightly.yml@main
+    with:
+      flutter-version: '3.41.6'
+      tag-prefix: 'desktop/nightly-'
+      app-name: 'browser'
+      base-branch: 'main'
+    secrets:
+      macos-code-sign-identity: ${{ secrets.MACOS_CODE_SIGN_IDENTITY }}
+      macos-certificate: ${{ secrets.MACOS_CERTIFICATE }}
+      macos-certificate-password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+      macos-keychain-password: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+      apple-id: ${{ secrets.APPLE_ID }}
+      apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
+      apple-app-specific-password: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      macos-app-bundle-id: ${{ secrets.MACOS_APP_BUNDLE_ID }}


### PR DESCRIPTION
## Summary
- Add nightly workflow using libnudget/nightly reusable workflow
- Runs daily at 08:00 UTC, skipping if no new commits since last nightly build
- Builds macOS app and uploads as prerelease

## Impact
- [x] New feature
- [x] Build / CI
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Resolves: https://github.com/bniladridas/browser/issues
- Resources: https://github.com/libnudget/nightly