### PR TITLE
fix[ux] :: disable ambient animation and limit theme probe to prevent macOS hover flicker

### DIFF
--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -2364,16 +2364,21 @@ class _BrowserPageState extends State<BrowserPage>
 
   bool get _ambientActive => widget.ambientToolbarEnabled;
 
+  // void _syncAmbientAnimation() {
+  //   // Disabled - causes hover flicker on macOS
+  //   if (_ambientActive) {
+  //     _ambientController ??= AnimationController(
+  //       vsync: this,
+  //       duration: const Duration(seconds: 14),
+  //     )..repeat();
+  //     return;
+  //   }
+  //   _ambientController?.dispose();
+  //   _ambientController = null;
+  // }
+
   void _syncAmbientAnimation() {
-    if (_ambientActive) {
-      _ambientController ??= AnimationController(
-        vsync: this,
-        duration: const Duration(seconds: 14),
-      )..repeat();
-      return;
-    }
-    _ambientController?.dispose();
-    _ambientController = null;
+    // Disabled - causes hover flicker on macOS
   }
 
   @override
@@ -3096,13 +3101,12 @@ class _BrowserPageState extends State<BrowserPage>
       }
       return;
     }
-    final now = DateTime.now();
-    final last = tab.lastAmbientProbeAt;
-    if (last != null &&
-        now.difference(last) < const Duration(milliseconds: 900)) {
+    // Run theme probe only once per page, not repeatedly
+    // This prevents hover flicker on macOS while still detecting page color
+    if (tab.lastAmbientProbeAt != null) {
       return;
     }
-    tab.lastAmbientProbeAt = now;
+    tab.lastAmbientProbeAt = DateTime.now();
 
     final controller = tab.webViewController;
     if (controller == null) return;


### PR DESCRIPTION
## Summary
- Disable the ambient animation controller loop to prevent continuous UI rebuilds
- Run the theme color probe only once per page load instead of throttling to every 900ms
- Both changes work together to eliminate pointer event interference with the WebView on macOS

## Impact
- [x] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [ ] Refactor / cleanup
- [ ] Tests

## Related Items
- Resolves #519

## Notes for reviewers
- Fixes hover/click flicker on webpage links when ambient toolbar mode is enabled on macOS
- Page color detection still works correctly — the ambient background continues to reflect the webpage theme, just probed once per page rather than on a repeating interval