### PR TITLE
chore[ci] :: bump Flutter version to 3.41.7 across workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-flutter
         with:
-          flutter-version: '3.41.6'
+          flutter-version: '3.41.7'
       - run: flutter pub get
       - name: Generate code
         run: flutter pub run build_runner build --delete-conflicting-outputs

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-flutter
         with:
-          flutter-version: '3.41.6'
+          flutter-version: '3.41.7'
       - run: flutter pub get
       - name: Create .env file
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
   nightly:
     uses: libnudget/nightly/.github/workflows/nightly.yml@main
     with:
-      flutter-version: '3.41.6'
+      flutter-version: '3.41.7'
       tag-prefix: 'desktop/nightly-'
       app-name: 'browser'
       base-branch: 'main'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: ./.github/actions/setup-flutter
         with:
-          flutter-version: '3.41.6'
+          flutter-version: '3.41.7'
 
       - run: flutter pub get
       - name: Create .env file

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-flutter
         with:
-          flutter-version: '3.41.6'
+          flutter-version: '3.41.7'
       - run: flutter pub get
       - name: Create .env file
         run: |


### PR DESCRIPTION
## Summary
- Updated Flutter version from `3.41.6` to `3.41.7` across all CI workflows (e2e, flutter, nightly, release, and ui-test)

## Impact
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security