### PR TITLE
fix[ux] :: improve volume path parsing to handle multiline mount output

### DIFF
--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -452,8 +452,8 @@ class SettingsDialog extends HookWidget {
                 (line) => line.contains('/Volumes/'),
                 orElse: () => '',
               );
-              final volumePathMatch = RegExp(r'(/Volumes/.+?)(?:\s|$)').firstMatch(volumeLine);
-              final volumePath = volumePathMatch?.group(1) ?? '';
+              final volumePathMatch = RegExp(r'(/Volumes/[^\r\n]*)').firstMatch(volumeLine);
+              final volumePath = volumePathMatch?.group(1)?.trim() ?? '';
               if (volumePath.isEmpty) {
                 await Process.run('hdiutil', ['detach', mountOutput.trim()]);
                 throw Exception('Could not find mounted volume');

--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -448,14 +448,16 @@ class SettingsDialog extends HookWidget {
               }
 
               final mountOutput = mountResult.stdout.toString();
-              final volumeMatch =
-                  RegExp(r'/Volumes/(\S+)').firstMatch(mountOutput);
-              if (volumeMatch == null) {
+              final volumeLine = mountOutput.split('\n').firstWhere(
+                (line) => line.contains('/Volumes/'),
+                orElse: () => '',
+              );
+              final volumePathMatch = RegExp(r'(/Volumes/.+?)(?:\s|$)').firstMatch(volumeLine);
+              final volumePath = volumePathMatch?.group(1) ?? '';
+              if (volumePath.isEmpty) {
                 await Process.run('hdiutil', ['detach', mountOutput.trim()]);
                 throw Exception('Could not find mounted volume');
               }
-
-              final volumePath = volumeMatch.group(0)!;
               final sourceApp = '$volumePath/$appName';
 
               // Check if source app exists


### PR DESCRIPTION
## Summary

- Fixed DMG volume path parsing to correctly handle volume paths that may contain spaces or carriage returns in `hdiutil` mount output
- Updated regex from `/Volumes/(\S+)` to `(/Volumes/[^\r\n]*)` and added line-by-line parsing to isolate the relevant `/Volumes/` line before applying the match, replacing the previous single-pass regex approach

## Impact

- [x] Bug fix

## Related Items

- Resolves #527

## Notes for reviewers

- The previous regex used `\S+` which stops at the first whitespace character, causing volume path extraction to fail for volume names containing spaces and resulting in a "Could not find mounted volume" error during app installation
- The fix first isolates the line containing `/Volumes/` from the `hdiutil` output, then extracts the full path (trimming any trailing whitespace or carriage returns) before proceeding with the mount