### PR TITLE
feat[features] :: include namespaced password storage with resilient secure/plaintext fallback

### DIFF
--- a/lib/features/password_storage.dart
+++ b/lib/features/password_storage.dart
@@ -5,9 +5,13 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:io';
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter/services.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class PasswordCredential {
   const PasswordCredential({
@@ -137,15 +141,190 @@ class FlutterSecureKeyValueStore implements SecureKeyValueStore {
   }
 }
 
+class SharedPreferencesKeyValueStore implements SecureKeyValueStore {
+  const SharedPreferencesKeyValueStore({
+    this.prefix = 'debug_password_store:',
+  });
+
+  @Deprecated(
+      'Stores passwords in plaintext. Use only for development/testing or as encrypted fallback.')
+  final String prefix;
+
+  String _key(String key) => '$prefix$key';
+
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key(key), value);
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_key(key));
+  }
+
+  @override
+  Future<Map<String, String>> readAll() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs
+        .getKeys()
+        .where((key) => key.startsWith(prefix))
+        .fold<Map<String, String>>(<String, String>{}, (all, key) {
+      final value = prefs.getString(key);
+      if (value != null) {
+        all[key.substring(prefix.length)] = value;
+      }
+      return all;
+    });
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key(key));
+  }
+}
+
+class ResilientSecureKeyValueStore implements SecureKeyValueStore {
+  static const String _fallbackPreferenceKey = 'use_fallback';
+
+  ResilientSecureKeyValueStore({
+    required SecureKeyValueStore primary,
+    required SecureKeyValueStore fallback,
+    bool? enableFallback,
+  })  : _primary = primary,
+        _fallback = fallback,
+        _enableFallback = enableFallback ?? (kDebugMode && Platform.isMacOS);
+
+  final SecureKeyValueStore _primary;
+  final SecureKeyValueStore _fallback;
+  final bool _enableFallback;
+  bool _fallbackActive = false;
+  bool _initialized = false;
+
+  bool get isUsingFallback => _fallbackActive;
+
+  Future<void> _ensureInitialized() async {
+    if (_initialized) return;
+    _initialized = true;
+    if (!_enableFallback) return;
+
+    try {
+      final stored = await _fallback.read(key: _fallbackPreferenceKey);
+      _fallbackActive = stored == 'true';
+    } catch (_) {
+      _fallbackActive = false;
+    }
+  }
+
+  Future<T> _run<T>({
+    required Future<T> Function(SecureKeyValueStore store) primary,
+    required Future<T> Function(SecureKeyValueStore store) fallback,
+  }) async {
+    await _ensureInitialized();
+    if (_fallbackActive) {
+      return fallback(_fallback);
+    }
+
+    try {
+      return await primary(_primary);
+    } on PlatformException {
+      if (!_enableFallback) rethrow;
+      _fallbackActive = true;
+      await _fallback.write(key: _fallbackPreferenceKey, value: 'true');
+      return fallback(_fallback);
+    }
+  }
+
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+  }) {
+    return _run<void>(
+      primary: (store) => store.write(key: key, value: value),
+      fallback: (store) => store.write(key: key, value: value),
+    );
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+  }) {
+    return _run<String?>(
+      primary: (store) => store.read(key: key),
+      fallback: (store) => store.read(key: key),
+    );
+  }
+
+  @override
+  Future<Map<String, String>> readAll() {
+    return _run<Map<String, String>>(
+      primary: (store) => store.readAll(),
+      fallback: (store) => store.readAll(),
+    );
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+  }) {
+    return _run<void>(
+      primary: (store) => store.delete(key: key),
+      fallback: (store) => store.delete(key: key),
+    );
+  }
+}
+
 class PasswordStorageRepository {
   PasswordStorageRepository({
     SecureKeyValueStore? store,
-  }) : _store = store ?? const FlutterSecureKeyValueStore();
+    String Function()? namespaceProvider,
+  })  : _store = store ?? _defaultStore(),
+        _namespaceProvider = namespaceProvider;
 
   static const String _credentialPrefix = 'password_credential:';
+  static const String _credentialIndexKey = 'password_credential:index';
+  static const String _defaultNamespace = 'default';
   final SecureKeyValueStore _store;
+  final String Function()? _namespaceProvider;
 
-  String _storageKey(String id) => '$_credentialPrefix$id';
+  static SecureKeyValueStore _defaultStore() {
+    if (kDebugMode && Platform.isMacOS) {
+      return const SharedPreferencesKeyValueStore();
+    }
+    return ResilientSecureKeyValueStore(
+      primary: const FlutterSecureKeyValueStore(),
+      fallback: const SharedPreferencesKeyValueStore(),
+    );
+  }
+
+  String? get _namespace {
+    final callResult = _namespaceProvider?.call();
+    final raw = callResult?.trim();
+    if (raw == null || raw.isEmpty) return null;
+    return raw;
+  }
+
+  String _namespacedKey(String key, {String? namespace}) {
+    final resolved = namespace ?? _namespace;
+    if (resolved == null) return key;
+    return '$resolved:$key';
+  }
+
+  String _storageKey(String id, {String? namespace}) =>
+      _namespacedKey('$_credentialPrefix$id', namespace: namespace);
+
+  String _indexKey({String? namespace}) =>
+      _namespacedKey(_credentialIndexKey, namespace: namespace);
 
   Future<void> saveCredential(PasswordCredential credential) async {
     final normalizedCredential = credential.copyWith(
@@ -156,6 +335,11 @@ class PasswordStorageRepository {
       key: _storageKey(normalizedCredential.id),
       value: payload,
     );
+    final ids = await _loadCredentialIds();
+    if (!ids.contains(normalizedCredential.id)) {
+      ids.add(normalizedCredential.id);
+      await _saveCredentialIds(ids);
+    }
   }
 
   Future<PasswordCredential?> getCredentialById(String id) async {
@@ -165,12 +349,25 @@ class PasswordStorageRepository {
   }
 
   Future<List<PasswordCredential>> listCredentials() async {
-    final allValues = await _store.readAll();
-    final credentials = allValues.entries
-        .where((entry) => entry.key.startsWith(_credentialPrefix))
-        .map((entry) => _decodeCredential(entry.value))
-        .whereType<PasswordCredential>()
-        .toList();
+    final ids = await _loadCredentialIds();
+    final credentials = <PasswordCredential>[];
+    var idsChanged = false;
+
+    for (final id in ids) {
+      final credential = await getCredentialById(id);
+      if (credential == null) {
+        idsChanged = true;
+        continue;
+      }
+      credentials.add(credential);
+    }
+
+    if (idsChanged) {
+      final existingIds =
+          credentials.map((credential) => credential.id).toList();
+      await _saveCredentialIds(existingIds);
+    }
+
     credentials.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
     return credentials;
   }
@@ -182,14 +379,46 @@ class PasswordStorageRepository {
       return false;
     }
     await _store.delete(key: key);
+    final ids = await _loadCredentialIds();
+    final removed = ids.remove(id);
+    if (removed) {
+      await _saveCredentialIds(ids);
+    }
     return true;
   }
 
   Future<void> clearAllCredentials() async {
-    final allValues = await _store.readAll();
-    final credentialKeys =
-        allValues.keys.where((key) => key.startsWith(_credentialPrefix));
-    await Future.wait(credentialKeys.map((key) => _store.delete(key: key)));
+    final namespace = _namespace;
+    final indexKey = _indexKey(namespace: namespace);
+    final rawIndex = await _store.read(key: indexKey);
+    if (rawIndex == null || rawIndex.isEmpty) {
+      return;
+    }
+    List<String> ids;
+    try {
+      final decoded = jsonDecode(rawIndex);
+      if (decoded is List) {
+        ids = decoded.whereType<String>().toList();
+      } else {
+        return;
+      }
+    } catch (_) {
+      return;
+    }
+    await Future.wait(ids.map((id) async {
+      await _store.delete(key: _storageKey(id));
+    }));
+    await _store.delete(key: _indexKey(namespace: namespace));
+
+    if (namespace == _defaultNamespace) {
+      await _store.delete(key: _credentialIndexKey);
+      final allValues = await _store.readAll();
+      for (final key in allValues.keys) {
+        if (key.startsWith(_credentialPrefix)) {
+          await _store.delete(key: key);
+        }
+      }
+    }
   }
 
   PasswordCredential? _decodeCredential(String rawValue) {
@@ -202,5 +431,72 @@ class PasswordStorageRepository {
     } catch (_) {
       return null;
     }
+  }
+
+  Future<List<String>> _loadCredentialIds() async {
+    final namespace = _namespace;
+    final rawIndex = await _store.read(key: _indexKey(namespace: namespace));
+    if (rawIndex != null && rawIndex.isNotEmpty) {
+      try {
+        final decoded = jsonDecode(rawIndex);
+        if (decoded is List) {
+          final ids = decoded.whereType<String>().toList();
+          if (ids.isNotEmpty) {
+            return ids.toSet().toList();
+          }
+        }
+      } catch (_) {
+        // Fall back to legacy scan below.
+      }
+    }
+
+    if (namespace == _defaultNamespace) {
+      final legacyRawIndex = await _store.read(key: _credentialIndexKey);
+      if (legacyRawIndex != null && legacyRawIndex.isNotEmpty) {
+        try {
+          final decoded = jsonDecode(legacyRawIndex);
+          if (decoded is List) {
+            final ids = decoded.whereType<String>().toList();
+            if (ids.isNotEmpty) {
+              for (final id in ids) {
+                final legacyPayload =
+                    await _store.read(key: '$_credentialPrefix$id');
+                if (legacyPayload != null) {
+                  await _store.write(
+                    key: _storageKey(id, namespace: namespace),
+                    value: legacyPayload,
+                  );
+                }
+              }
+              await _saveCredentialIds(ids);
+              return ids.toSet().toList();
+            }
+          }
+        } catch (_) {
+          // Fall through to scan below.
+        }
+      }
+    }
+
+    final allValues = await _store.readAll();
+    final keyPrefix = _namespace == null
+        ? _credentialPrefix
+        : '${_namespace!}:$_credentialPrefix';
+    final legacyIds = allValues.keys
+        .where((key) => key.startsWith(keyPrefix))
+        .map((key) => key.substring(keyPrefix.length))
+        .toSet()
+        .toList();
+    if (legacyIds.isNotEmpty) {
+      await _saveCredentialIds(legacyIds);
+    }
+    return legacyIds;
+  }
+
+  Future<void> _saveCredentialIds(List<String> ids) {
+    return _store.write(
+      key: _indexKey(),
+      value: jsonEncode(ids.toSet().toList()),
+    );
   }
 }

--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -449,10 +449,11 @@ class SettingsDialog extends HookWidget {
 
               final mountOutput = mountResult.stdout.toString();
               final volumeLine = mountOutput.split('\n').firstWhere(
-                (line) => line.contains('/Volumes/'),
-                orElse: () => '',
-              );
-              final volumePathMatch = RegExp(r'(/Volumes/[^\r\n]*)').firstMatch(volumeLine);
+                    (line) => line.contains('/Volumes/'),
+                    orElse: () => '',
+                  );
+              final volumePathMatch =
+                  RegExp(r'(/Volumes/[^\r\n]*)').firstMatch(volumeLine);
               final volumePath = volumePathMatch?.group(1)?.trim() ?? '';
               if (volumePath.isEmpty) {
                 await Process.run('hdiutil', ['detach', mountOutput.trim()]);
@@ -2140,7 +2141,9 @@ class _BrowserPageState extends State<BrowserPage>
   bool _isOnline = true;
   final ConnectivityService _connectivityService = ConnectivityService();
   final PasswordStorageRepository _passwordRepository =
-      PasswordStorageRepository();
+      PasswordStorageRepository(
+    namespaceProvider: () => profileManager.activeProfileId ?? 'default',
+  );
   StreamSubscription<bool>? _connectivitySubscription;
   late AnimationController _refreshIconController;
   AnimationController? _ambientController;
@@ -3575,13 +3578,30 @@ class _BrowserPageState extends State<BrowserPage>
 
     switch (action) {
       case SavePasswordAction.save:
-        final repository = PasswordStorageRepository();
-        final credential = PasswordCredential.create(
-          origin: promptData.origin,
-          username: promptData.username,
-          password: promptData.password,
-        );
-        await repository.saveCredential(credential);
+        try {
+          final repository = PasswordStorageRepository(
+            namespaceProvider: () =>
+                profileManager.activeProfileId ?? 'default',
+          );
+          final credential = PasswordCredential.create(
+            origin: promptData.origin,
+            username: promptData.username,
+            password: promptData.password,
+          );
+          await repository.saveCredential(credential);
+          if (!mounted) return;
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Password saved')),
+          );
+        } catch (e, s) {
+          logger.e('Failed to save password', error: e, stackTrace: s);
+          if (!mounted) return;
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Password could not be saved on this build'),
+            ),
+          );
+        }
         break;
       case SavePasswordAction.neverForSite:
         await policy.setNeverSave(promptData.origin);
@@ -3608,7 +3628,11 @@ class _BrowserPageState extends State<BrowserPage>
       final actualUrl = await tab.webViewController!.currentUrl();
       if (actualUrl == null) return;
 
-      final autofillService = PasswordAutofillService();
+      final autofillService = PasswordAutofillService(
+        repository: PasswordStorageRepository(
+          namespaceProvider: () => profileManager.activeProfileId ?? 'default',
+        ),
+      );
       final matches = await autofillService.getMatchingCredentials(actualUrl);
 
       if (matches.isEmpty) return;
@@ -4581,8 +4605,8 @@ class _BrowserPageState extends State<BrowserPage>
             ? await _isSafeFaviconUrl(resolvedFavicon)
             : false;
     final faviconReturns200 = resolvedFavicon != null &&
-        resolvedFavicon.isNotEmpty &&
-        resolvedFavicon.contains('google.com/s2/favicons')
+            resolvedFavicon.isNotEmpty &&
+            resolvedFavicon.contains('google.com/s2/favicons')
         ? await _faviconUrlReturns200(resolvedFavicon)
         : true;
     if (resolvedFavicon != null &&

--- a/lib/ux/password_vault_screen.dart
+++ b/lib/ux/password_vault_screen.dart
@@ -10,6 +10,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import '../features/password_storage.dart';
 import '../logging/logger.dart';
+import '../main.dart' show profileManager;
 
 class PasswordVaultScreen extends StatefulWidget {
   const PasswordVaultScreen({
@@ -35,7 +36,10 @@ class _PasswordVaultScreenState extends State<PasswordVaultScreen> {
   @override
   void initState() {
     super.initState();
-    _repository = widget._repository ?? PasswordStorageRepository();
+    _repository = widget._repository ??
+        PasswordStorageRepository(
+          namespaceProvider: () => profileManager.activeProfileId ?? 'default',
+        );
     _loadCredentials();
   }
 
@@ -164,6 +168,13 @@ class _PasswordVaultScreenState extends State<PasswordVaultScreen> {
       leading: IconButton(
         icon: const Icon(Icons.arrow_back_ios_new, size: 20),
         visualDensity: VisualDensity.compact,
+        style: ButtonStyle(
+          overlayColor: WidgetStateProperty.resolveWith<Color?>(
+            (states) => states.contains(WidgetState.hovered)
+                ? Colors.transparent
+                : null,
+          ),
+        ),
         onPressed: () => Navigator.of(context).maybePop(),
       ),
       titleSpacing: isMacDesktop ? 0 : null,
@@ -175,8 +186,14 @@ class _PasswordVaultScreenState extends State<PasswordVaultScreen> {
         if (_credentials.isNotEmpty)
           IconButton(
             icon: const Icon(Icons.delete_sweep, size: 20),
-            tooltip: 'Delete All',
             visualDensity: VisualDensity.compact,
+            style: ButtonStyle(
+              overlayColor: WidgetStateProperty.resolveWith<Color?>(
+                (states) => states.contains(WidgetState.hovered)
+                    ? Colors.transparent
+                    : null,
+              ),
+            ),
             onPressed: _deleteAll,
           ),
       ],
@@ -269,8 +286,8 @@ class _PasswordVaultScreenState extends State<PasswordVaultScreen> {
                                 'Password',
                               ),
                             );
-                        },
-                      ),
+                          },
+                        ),
             ),
           ],
         ),
@@ -326,6 +343,8 @@ class _PasswordTileState extends State<_PasswordTile> {
           vertical: _kTileVerticalPadding,
         ),
         childrenPadding: EdgeInsets.zero,
+        shape: RoundedRectangleBorder(side: BorderSide.none),
+        collapsedShape: RoundedRectangleBorder(side: BorderSide.none),
         title: Text(
           widget.credential.origin,
           style: theme.textTheme.bodyMedium?.copyWith(
@@ -360,7 +379,6 @@ class _PasswordTileState extends State<_PasswordTile> {
                     ),
                     IconButton(
                       icon: const Icon(Icons.copy, size: _kIconButtonSize),
-                      tooltip: 'Copy username',
                       visualDensity: VisualDensity.compact,
                       onPressed: widget.onCopyUsername,
                     ),
@@ -381,14 +399,12 @@ class _PasswordTileState extends State<_PasswordTile> {
                         _showPassword ? Icons.visibility_off : Icons.visibility,
                         size: _kIconButtonSize,
                       ),
-                      tooltip: _showPassword ? 'Hide' : 'Show',
                       visualDensity: VisualDensity.compact,
                       onPressed: () =>
                           setState(() => _showPassword = !_showPassword),
                     ),
                     IconButton(
                       icon: const Icon(Icons.copy, size: _kIconButtonSize),
-                      tooltip: 'Copy password',
                       visualDensity: VisualDensity.compact,
                       onPressed: widget.onCopyPassword,
                     ),

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)$(CFBundleIdentifier)</string>
+	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.device.camera</key>

--- a/test/features/password_storage_test.dart
+++ b/test/features/password_storage_test.dart
@@ -5,7 +5,9 @@
 // found in the LICENSE file.
 
 import 'package:browser/features/password_storage.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class _FakeSecureStore implements SecureKeyValueStore {
   final Map<String, String> _values = {};
@@ -38,7 +40,50 @@ class _FakeSecureStore implements SecureKeyValueStore {
   }
 }
 
+class _ThrowingSecureStore implements SecureKeyValueStore {
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+  }) async {
+    throw PlatformException(
+      code: '-34018',
+      message: "A required entitlement isn't present.",
+    );
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+  }) async {
+    throw PlatformException(
+      code: '-34018',
+      message: "A required entitlement isn't present.",
+    );
+  }
+
+  @override
+  Future<Map<String, String>> readAll() async {
+    throw PlatformException(
+      code: '-34018',
+      message: "A required entitlement isn't present.",
+    );
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+  }) async {
+    throw PlatformException(
+      code: '-34018',
+      message: "A required entitlement isn't present.",
+    );
+  }
+}
+
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('PasswordCredential', () {
     test('create should populate metadata', () {
       final credential = PasswordCredential.create(
@@ -76,6 +121,10 @@ void main() {
   });
 
   group('PasswordStorageRepository', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
     test('save and fetch credential by id', () async {
       final store = _FakeSecureStore();
       final repo = PasswordStorageRepository(store: store);
@@ -126,6 +175,32 @@ void main() {
       expect(all.last.id, 'old');
     });
 
+    test('listCredentials should migrate legacy stored credentials into index',
+        () async {
+      final store = _FakeSecureStore();
+      final repo = PasswordStorageRepository(store: store);
+      final legacy = PasswordCredential(
+        id: 'legacy',
+        origin: 'https://example.com',
+        username: 'alice',
+        password: 'pw',
+        createdAt: DateTime.parse('2026-03-01T00:00:00Z'),
+        updatedAt: DateTime.parse('2026-03-01T00:00:00Z'),
+      );
+
+      await store.write(
+        key: 'password_credential:${legacy.id}',
+        value:
+            '{"id":"legacy","origin":"https://example.com","username":"alice","password":"pw","createdAt":"2026-03-01T00:00:00.000Z","updatedAt":"2026-03-01T00:00:00.000Z"}',
+      );
+
+      final loaded = await repo.listCredentials();
+
+      expect(loaded, hasLength(1));
+      expect(loaded.first.id, legacy.id);
+      expect(await store.read(key: 'password_credential:index'), '["legacy"]');
+    });
+
     test('deleteCredential should return false for missing id', () async {
       final repo = PasswordStorageRepository(store: _FakeSecureStore());
       final deleted = await repo.deleteCredential('missing');
@@ -148,6 +223,68 @@ void main() {
 
       expect(await repo.getCredentialById(credential.id), isNull);
       expect(await store.read(key: 'other:key'), 'keep');
+    });
+
+    test('should fall back when secure storage fails in debug mode', () async {
+      final repo = PasswordStorageRepository(
+        store: ResilientSecureKeyValueStore(
+          primary: _ThrowingSecureStore(),
+          fallback: const SharedPreferencesKeyValueStore(prefix: 'test:'),
+          enableFallback: true,
+        ),
+      );
+
+      final credential = PasswordCredential.create(
+        origin: 'https://example.com',
+        username: 'debug-user',
+        password: 'pw',
+      );
+
+      await repo.saveCredential(credential);
+      final loaded = await repo.listCredentials();
+
+      expect(loaded, hasLength(1));
+      expect(loaded.first.username, 'debug-user');
+      final prefs = await SharedPreferences.getInstance();
+      expect(
+        prefs.getString('test:password_credential:index'),
+        contains(credential.id),
+      );
+    });
+
+    test('should isolate credentials by namespace', () async {
+      final store = _FakeSecureStore();
+      final workRepo = PasswordStorageRepository(
+        store: store,
+        namespaceProvider: () => 'work',
+      );
+      final personalRepo = PasswordStorageRepository(
+        store: store,
+        namespaceProvider: () => 'personal',
+      );
+
+      await workRepo.saveCredential(
+        PasswordCredential.create(
+          origin: 'https://example.com',
+          username: 'work-user',
+          password: 'pw1',
+        ),
+      );
+      await personalRepo.saveCredential(
+        PasswordCredential.create(
+          origin: 'https://example.com',
+          username: 'personal-user',
+          password: 'pw2',
+        ),
+      );
+
+      final workCredentials = await workRepo.listCredentials();
+      final personalCredentials = await personalRepo.listCredentials();
+
+      expect(workCredentials, hasLength(1));
+      expect(workCredentials.first.username, 'work-user');
+      expect(personalCredentials, hasLength(1));
+      expect(personalCredentials.first.username, 'personal-user');
     });
   });
 }


### PR DESCRIPTION
## Summary
- Add `SharedPreferencesKeyValueStore` as a plaintext fallback store (marked `@Deprecated`) for use in development or when secure storage is unavailable
- Introduce `ResilientSecureKeyValueStore` that transparently falls back to `SharedPreferencesKeyValueStore` on `PlatformException`, persisting the fallback state across sessions
- Replace `readAll`-based credential scanning with an explicit JSON index key (`password_credential:index`) for more reliable and efficient listing
- Add namespace support to `PasswordStorageRepository` via a `namespaceProvider` callback, isolating credentials per active profile
- Wire `namespaceProvider` using `profileManager.activeProfileId` in `BrowserPage` and `PasswordVaultScreen`
- Add legacy credential migration: on first load, existing unindexed credentials are detected, migrated into the index, and re-keyed under the resolved namespace
- Wrap password save action in a try/catch with user-facing snackbar feedback on success or failure
- Scope `PasswordAutofillService` and save-action repository instances to the active profile namespace
- Add `keychain-access-groups` entitlement to `Release.entitlements` for macOS Keychain access
- Remove hover overlay effects from vault UI icon buttons and strip tooltips for a cleaner interaction style
- Remove border from `ExpansionTile` in the password vault credential list

## Impact
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests
- [ ] Performance
- [x] Security

## Related Items
- Resolves #530

## Notes for reviewers
- `SharedPreferencesKeyValueStore` stores passwords in plaintext and is intentionally marked `@Deprecated`; it should only be used in debug/development or as an encrypted fallback
- The `ResilientSecureKeyValueStore` fallback is automatically enabled on macOS debug builds; the `enableFallback` parameter allows explicit control in tests
- Legacy credentials stored without an index are automatically detected via a full `readAll` scan and migrated on first `listCredentials` call, after which the scan is no longer needed
- Namespace isolation ensures that credentials saved under one profile are never visible to another