### PR TITLE
feat[ci] :: extend auto-label workflow to trigger on issue opens

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -10,6 +10,8 @@ name: Auto Label PRs
 on:
   pull_request:
     types: [opened, synchronize]
+  issues:
+    types: [opened]
 
 jobs:
   label:
@@ -17,6 +19,7 @@ jobs:
     if: github.repository_owner == 'bniladridas'
     permissions:
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v4
       - uses: libnudget/auto-label@v1


### PR DESCRIPTION
## Summary

- Enable auto-labeling workflow to trigger on newly opened issues in addition to pull requests
- Add `issues: write` permission to allow the workflow to apply labels to issues

## Impact

- [ ] New feature
- [ ] Bug fix
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items

- Fixes #533

## Notes for reviewers

- The `libnudget/auto-label@v1` action already supports issue labeling, so no additional action configuration is required
- Only the `opened` event type is used for issues, consistent with the intent to categorize new issues on creation