### PR TITLE
fix[ux] :: use `ditto` instead of `cp -R` for app installation

### DIFF
--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -473,8 +473,8 @@ class SettingsDialog extends HookWidget {
                 await Process.run('mv', [appPath, backupPath]);
               }
 
-              final cpResult =
-                  await Process.run('cp', ['-R', sourceApp, '/Applications/']);
+              final cpResult = await Process.run(
+                  'ditto', ['-rsrc', sourceApp, '/Applications/']);
               if (cpResult.exitCode != 0) {
                 // Restore backup
                 if (await Directory(backupPath).exists()) {


### PR DESCRIPTION
## Summary

- Replace `cp -R` with `ditto -rsrc` for copying app bundle during update installation
- `ditto` better handles macOS app bundles and preserves resource forks and metadata, which may resolve copying failures when the app is in use

## Impact

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items

- Fixes #543

## Notes for reviewers

- `ditto` preserves resource forks and HFS+ metadata better than `cp`, making it more appropriate for macOS `.app` bundles
- Tested manually: mounting DMG and copying with `ditto` succeeds
- Should resolve "Installation failed" messages that could occur during updates

## Summary by CodeRabbit

- **Bug Fixes**
    - Improved macOS application update installation process for more reliable app replacement.