### PR TITLE
fix[ci] :: extend auto-label workflow to trigger on issue reopens

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     types: [opened, synchronize]
   issues:
-    types: [opened]
+    types: [opened, reopened]
 
 jobs:
   label:


### PR DESCRIPTION
Update auto-label workflow to also trigger on issue reopen, allowing re-labeling and re-reacting if needed.

## Summary
- Add 'reopened' to issue types in auto-label.yml
- Workflow now runs when issues are reopened, potentially fixing labels/reactions

## Impact
- [ ] New feature
- [ ] Bug fix
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Addresses issue #533 (auto-label improvements)