### PR TITLE
fix[ci] :: include `contents: read` permission to auto-label workflow

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'bniladridas'
     permissions:
+      contents: read
       pull-requests: write
       issues: write
     steps:


### PR DESCRIPTION
## Summary
- Include contents: read permission in auto-label workflow to enable emoji reaction API calls

## Impact
- [ ] New feature
- [ ] Bug fix
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Fixes reaction API failures in auto-label workflow

## Notes for reviewers
- The permission may resolve gh api errors for adding reactions
- If still failing, reaction code can be removed temporarily