### PR TITLE
fix[ci] :: include `GH_TOKEN` env var in auto-label workflow

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -24,3 +24,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: libnudget/auto-label@v1
+        env:
+          GH_TOKEN: ${{ secrets.REACTIONS_TOKEN }}


### PR DESCRIPTION
Update auto-label workflow to use a PAT for reactions API calls, bypassing GITHUB_TOKEN limitations.

## Summary
- Add env GH_TOKEN: ${{ secrets.REACTIONS_TOKEN }} to libnudget/auto-label action
- Requires creating REACTIONS_TOKEN secret with PAT (repo scope)

## Impact
- [x] Build / CI
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Fixes reaction API failures

## Notes for reviewers
- Create secret REACTIONS_TOKEN with PAT for repo access
- Reactions will work once secret is added and PR merged