### PR TITLE
fix[ci] :: remove `GH_TOKEN` env var from auto-label workflow

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -24,5 +24,3 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: libnudget/auto-label@v1
-        env:
-          GH_TOKEN: ${{ secrets.REACTIONS_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove custom REACTIONS_TOKEN env var and use default GITHUB_TOKEN for the auto-label action

## Impact
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Supersedes #555 which attempted to use a custom token but failed due to permissions
- Resolves auto-label workflow failures

## Notes for reviewers
- This simplifies the setup by using the default GITHUB_TOKEN with explicit permissions instead of requiring a custom PAT secret.