### PR TITLE
fix[ci] :: remove `contents: read` permission from auto-label workflow

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'bniladridas'
     permissions:
-      contents: read
       pull-requests: write
       issues: write
     steps:


### PR DESCRIPTION
## Summary
- Removed contents: read permission from auto-label.yml workflow as it's not required for the action.

## Impact
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Related to #553, #557, #555, #551, #534, #501

## Notes for reviewers
- This change optimizes the permissions for the auto-label GitHub Action.