### PR TITLE
fix[ux] :: replace `CompositedTransformFollower` with `Positioned` for URL autocomplete overlay placement

### DIFF
--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -2291,11 +2291,13 @@ class _BrowserPageState extends State<BrowserPage>
   StreamSubscription<bool>? _connectivitySubscription;
   late AnimationController _refreshIconController;
   AnimationController? _ambientController;
-  final LayerLink _urlAutocompleteLink = LayerLink();
   BuildContext? _urlAutocompleteTargetContext;
   OverlayEntry? _urlAutocompleteOverlayEntry;
   List<String> _urlAutocompleteOptions = const <String>[];
   double? _urlAutocompleteTargetWidth;
+  double _urlAutocompleteOverlayLeft = 0;
+  double _urlAutocompleteOverlayTop = 0;
+  double _urlAutocompleteOverlayBottom = 0;
   bool _urlAutocompleteOverlayUpdateQueued = false;
   int _lastUrlAutocompleteOverlayPointerDownMs = 0;
   Future<void> _historySaveQueue = Future<void>.value();
@@ -2999,6 +3001,11 @@ class _BrowserPageState extends State<BrowserPage>
           final showAbove = spaceBelow < _urlAutocompleteOverlayFlipThreshold &&
               spaceAbove > spaceBelow;
           _urlAutocompleteShowAbove = showAbove;
+          _urlAutocompleteOverlayLeft = dx;
+          _urlAutocompleteOverlayTop =
+              dy + targetBox.size.height + _urlAutocompleteOverlayOffset;
+          _urlAutocompleteOverlayBottom =
+              overlayBox.size.height - dy + _urlAutocompleteOverlayOffset;
           _urlAutocompleteOverlayMaxWidth =
               (overlayBox.size.width - dx - minMargin).clamp(
                   _urlAutocompleteOverlayMinWidth,
@@ -3140,18 +3147,14 @@ class _BrowserPageState extends State<BrowserPage>
                     _removeUrlAutocompleteOverlay();
                   },
                 ),
-                CompositedTransformFollower(
-                  link: _urlAutocompleteLink,
-                  showWhenUnlinked: false,
-                  targetAnchor: _urlAutocompleteShowAbove
-                      ? Alignment.topLeft
-                      : Alignment.bottomLeft,
-                  followerAnchor: _urlAutocompleteShowAbove
-                      ? Alignment.bottomLeft
-                      : Alignment.topLeft,
-                  offset: _urlAutocompleteShowAbove
-                      ? const Offset(0, -_urlAutocompleteOverlayOffset)
-                      : const Offset(0, _urlAutocompleteOverlayOffset),
+                Positioned(
+                  left: _urlAutocompleteOverlayLeft,
+                  top: _urlAutocompleteShowAbove
+                      ? null
+                      : _urlAutocompleteOverlayTop,
+                  bottom: _urlAutocompleteShowAbove
+                      ? _urlAutocompleteOverlayBottom
+                      : null,
                   child: Listener(
                     behavior: HitTestBehavior.opaque,
                     onPointerDown: (_) {
@@ -7693,73 +7696,69 @@ class _BrowserPageState extends State<BrowserPage>
                                   )
                                 : KeyedSubtree(
                                     key: const ValueKey('url_field'),
-                                    child: CompositedTransformTarget(
-                                      link: _urlAutocompleteLink,
-                                      child: Builder(
-                                        builder: (context) {
-                                          _urlAutocompleteTargetContext =
-                                              context;
-                                          return TextField(
-                                            key: const Key('browser.url_field'),
-                                            controller: activeTab.urlController,
-                                            focusNode: activeTab.urlFocusNode,
-                                            onChanged: (_) =>
-                                                _updateUrlAutocompleteOverlay(
-                                              activeTab,
-                                            ),
-                                            style: TextStyle(
-                                              color: toolbarForeground,
+                                    child: Builder(
+                                      builder: (context) {
+                                        _urlAutocompleteTargetContext = context;
+                                        return TextField(
+                                          key: const Key('browser.url_field'),
+                                          controller: activeTab.urlController,
+                                          focusNode: activeTab.urlFocusNode,
+                                          onChanged: (_) =>
+                                              _updateUrlAutocompleteOverlay(
+                                            activeTab,
+                                          ),
+                                          style: TextStyle(
+                                            color: toolbarForeground,
+                                            fontSize: 13,
+                                          ),
+                                          decoration: InputDecoration(
+                                            hintText: 'Search or enter URL',
+                                            hintStyle: TextStyle(
+                                              color: toolbarForeground
+                                                  .withValues(alpha: 0.72),
                                               fontSize: 13,
                                             ),
-                                            decoration: InputDecoration(
-                                              hintText: 'Search or enter URL',
-                                              hintStyle: TextStyle(
-                                                color: toolbarForeground
-                                                    .withValues(alpha: 0.72),
-                                                fontSize: 13,
-                                              ),
-                                              border: InputBorder.none,
-                                              contentPadding:
-                                                  const EdgeInsets.symmetric(
-                                                vertical: 10,
-                                              ),
+                                            border: InputBorder.none,
+                                            contentPadding:
+                                                const EdgeInsets.symmetric(
+                                              vertical: 10,
                                             ),
-                                            onTap: () {
-                                              _cancelAddressBarAutoHide();
-                                              _setActiveTabUrlObscured(false);
-                                              if (widget
-                                                      .aiSearchSuggestionsEnabled &&
-                                                  activeTab.urlController.text
-                                                      .trim()
-                                                      .isEmpty) {
-                                                _showAiSearchSuggestionsSheet();
-                                              } else {
-                                                _updateUrlAutocompleteOverlay(
-                                                  activeTab,
-                                                );
-                                              }
-                                            },
-                                            onSubmitted: (value) {
-                                              _removeUrlAutocompleteOverlay();
-                                              activeTab.urlFocusNode.unfocus();
-                                              final decision =
-                                                  resolveUrlSubmission(
-                                                submittedValue: value,
-                                                aiSearchSuggestionsEnabled: widget
-                                                    .aiSearchSuggestionsEnabled,
+                                          ),
+                                          onTap: () {
+                                            _cancelAddressBarAutoHide();
+                                            _setActiveTabUrlObscured(false);
+                                            if (widget
+                                                    .aiSearchSuggestionsEnabled &&
+                                                activeTab.urlController.text
+                                                    .trim()
+                                                    .isEmpty) {
+                                              _showAiSearchSuggestionsSheet();
+                                            } else {
+                                              _updateUrlAutocompleteOverlay(
+                                                activeTab,
                                               );
-                                              if (decision
-                                                  .shouldShowAiSuggestions) {
-                                                _showAiSearchSuggestionsSheet();
-                                              }
-                                              if (decision.shouldLoadUrl) {
-                                                _loadUrl(
-                                                    decision.normalizedInput);
-                                              }
-                                            },
-                                          );
-                                        },
-                                      ),
+                                            }
+                                          },
+                                          onSubmitted: (value) {
+                                            _removeUrlAutocompleteOverlay();
+                                            activeTab.urlFocusNode.unfocus();
+                                            final decision =
+                                                resolveUrlSubmission(
+                                              submittedValue: value,
+                                              aiSearchSuggestionsEnabled: widget
+                                                  .aiSearchSuggestionsEnabled,
+                                            );
+                                            if (decision
+                                                .shouldShowAiSuggestions) {
+                                              _showAiSearchSuggestionsSheet();
+                                            }
+                                            if (decision.shouldLoadUrl) {
+                                              _loadUrl(
+                                                  decision.normalizedInput);
+                                            }
+                                          },
+                                        );
+                                      },
                                     ),
                                   ),
                           ),


### PR DESCRIPTION
## Summary

- Replace the URL autocomplete overlay `CompositedTransformTarget`/`CompositedTransformFollower` (`LayerLink`) approach with direct `Positioned` widget placement using explicitly measured coordinates
- Store the overlay's `left`, `top`, and `bottom` values computed from the URL field's render box position, replacing the composited transform follower anchoring logic
- Remove the `LayerLink _urlAutocompleteLink` field and the wrapping `CompositedTransformTarget` around the URL `TextField`, simplifying the widget tree
- Prevent Flutter layer assertion errors that occurred when the URL autocomplete overlay remained open across rebuilds, tab switches, or URL bar visibility changes

## Impact

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items

- Resolves #572
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers

- The overlay position is now fully driven by the measured `dx`/`dy` from the target render box, consistent with how `_urlAutocompleteOverlayMaxWidth` and `_urlAutocompleteShowAbove` were already being computed.
- The `showWhenUnlinked: false` guard previously provided by `CompositedTransformFollower` is no longer needed since the overlay is explicitly removed when the target is no longer valid.

## Verification Steps

- `flutter analyze lib/ux/browser_page.dart`
- Open the URL bar, trigger autocomplete suggestions, then switch tabs while the popup is visible and confirm no layer assertion errors occur
- Verify the autocomplete popup correctly appears above and below the URL field depending on available screen space