### PR TITLE
feat[ux] :: include macOS menu bar status item with show/hide/quit controls and background window support

### DIFF
--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -36,23 +36,158 @@ extension WKWebViewConfiguration {
   }
 }
 
+final class BrowserMenuBarController: NSObject {
+  static let shared = BrowserMenuBarController()
+
+  private var statusItem: NSStatusItem?
+  private var creationAttempts = 0
+
+  func install(reason: String) {
+    creationAttempts += 1
+    if let existingItem = statusItem,
+       let button = existingItem.button,
+       button.window != nil {
+      existingItem.isVisible = true
+      return
+    }
+    if let existingItem = statusItem {
+      NSStatusBar.system.removeStatusItem(existingItem)
+      statusItem = nil
+    }
+
+    let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+    statusItem = item
+    item.isVisible = true
+
+    if let button = item.button {
+      button.image = makeStatusItemImage()
+      button.imagePosition = .imageOnly
+      button.title = ""
+      button.toolTip = "Browser"
+      button.target = self
+      button.action = #selector(handleStatusItemButtonPress(_:))
+      button.sizeToFit()
+      button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+    }
+
+    let menu = NSMenu()
+    menu.addItem(
+      withTitle: "Show browser",
+      action: #selector(showMainWindow(_:)),
+      keyEquivalent: ""
+    )
+    menu.addItem(
+      withTitle: "Hide browser",
+      action: #selector(hideMainWindow(_:)),
+      keyEquivalent: ""
+    )
+    menu.addItem(NSMenuItem.separator())
+    menu.addItem(
+      withTitle: "Quit",
+      action: #selector(quitApplication(_:)),
+      keyEquivalent: "q"
+    )
+    menu.items.forEach { $0.target = self }
+    item.menu = menu
+  }
+
+  private func makeStatusItemImage() -> NSImage? {
+    guard let image = NSApp.applicationIconImage.copy() as? NSImage else {
+      return nil
+    }
+    image.isTemplate = false
+    image.size = NSSize(width: 18, height: 18)
+    return image
+  }
+
+  private func mainFlutterWindow() -> NSWindow? {
+    if let window = NSApp.windows.first(where: { $0 is MainFlutterWindow }) {
+      return window
+    }
+    return NSApp.mainWindow ?? NSApp.windows.first
+  }
+
+  @objc func showMainWindow(_ sender: Any?) {
+    guard let window = mainFlutterWindow() else { return }
+    if window.isMiniaturized {
+      window.deminiaturize(nil)
+    }
+    NSApp.activate(ignoringOtherApps: true)
+    window.makeKeyAndOrderFront(nil)
+  }
+
+  @objc func hideMainWindow(_ sender: Any?) {
+    mainFlutterWindow()?.orderOut(nil)
+  }
+
+  @objc func quitApplication(_ sender: Any?) {
+    NSApp.terminate(nil)
+  }
+
+  @objc private func handleStatusItemButtonPress(_ sender: Any?) {
+    if let event = NSApp.currentEvent, event.type == .rightMouseUp {
+      statusItem?.button?.performClick(nil)
+      return
+    }
+    if let window = mainFlutterWindow(), window.isVisible {
+      hideMainWindow(nil)
+    } else {
+      showMainWindow(nil)
+    }
+  }
+}
+
 @main
 class AppDelegate: FlutterAppDelegate {
+
   override func applicationDidFinishLaunching(_ notification: Notification) {
     WKWebViewFullscreenBootstrap.enable()
     super.applicationDidFinishLaunching(notification)
 
     NSApp.setActivationPolicy(.regular)
-    NSApp.activate(ignoringOtherApps: true)
-    NSApp.mainWindow?.makeKeyAndOrderFront(nil)
-    NSApp.windows.first?.makeKeyAndOrderFront(nil)
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(handleApplicationDidBecomeActive),
+      name: NSApplication.didBecomeActiveNotification,
+      object: nil
+    )
+    scheduleStatusItemSetup()
+    BrowserMenuBarController.shared.showMainWindow(nil)
   }
 
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    return false
+  }
+
+  override func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+    if !flag {
+      BrowserMenuBarController.shared.showMainWindow(nil)
+    }
     return true
   }
 
   override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
     return true
+  }
+
+  deinit {
+    NotificationCenter.default.removeObserver(self)
+  }
+
+  private func scheduleStatusItemSetup() {
+    DispatchQueue.main.async { [weak self] in
+      self?.ensureStatusItemVisible(reason: "initial async")
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) { [weak self] in
+      self?.ensureStatusItemVisible(reason: "launch retry")
+    }
+  }
+
+  @objc private func handleApplicationDidBecomeActive() {
+    ensureStatusItemVisible(reason: "app became active")
+  }
+
+  private func ensureStatusItemVisible(reason: String) {
+    BrowserMenuBarController.shared.install(reason: reason)
   }
 }

--- a/macos/Runner/Base.lproj/MainMenu.xib
+++ b/macos/Runner/Base.lproj/MainMenu.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Runner" customModuleProvider="target">
+        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="browser" customModuleProvider="target">
             <connections>
                 <outlet property="applicationMenu" destination="uQy-DD-JDr" id="XBo-yE-nKs"/>
                 <outlet property="mainFlutterWindow" destination="QvC-M9-y7g" id="gIp-Ho-8D9"/>
@@ -330,7 +330,7 @@
             </items>
             <point key="canvasLocation" x="142" y="-258"/>
         </menu>
-        <window title="APP_NAME" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g" customClass="MainFlutterWindow" customModule="Runner" customModuleProvider="target">
+        <window title="APP_NAME" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g" customClass="MainFlutterWindow" customModule="browser" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <rect key="contentRect" x="335" y="390" width="800" height="600"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1577"/>

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,7 +1,7 @@
 import Cocoa
 import FlutterMacOS
 
-class MainFlutterWindow: NSWindow {
+class MainFlutterWindow: NSWindow, NSWindowDelegate {
   override func awakeFromNib() {
     let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
@@ -11,6 +11,9 @@ class MainFlutterWindow: NSWindow {
     RegisterGeneratedPlugins(registry: flutterViewController)
 
     super.awakeFromNib()
+
+    BrowserMenuBarController.shared.install(reason: "window awakeFromNib")
+    delegate = self
 
     // Hide window initially
     self.alphaValue = 0
@@ -22,5 +25,10 @@ class MainFlutterWindow: NSWindow {
         self.animator().alphaValue = 1.0
       }, completionHandler: nil)
     }
+  }
+
+  func windowShouldClose(_ sender: NSWindow) -> Bool {
+    orderOut(nil)
+    return false
   }
 }


### PR DESCRIPTION
## Summary
- Add a `BrowserMenuBarController` singleton that installs a macOS status bar icon using the app's icon resized to 18×18
- Left-clicking the status item toggles the main window's visibility; right-clicking opens a context menu with Show Browser, Hide Browser, and Quit options
- Prevent the app from terminating when the last window is closed, keeping it alive in the menu bar instead
- Re-show the main window when the app is reopened via Dock (via `applicationShouldHandleReopen`) and ensure the status item is installed reliably at launch and on app activation
- Intercept window close button to hide the window rather than destroy it, keeping the app running in the background
- Update XIB module references from `Runner` to `browser` for `AppDelegate` and `MainFlutterWindow`

## Impact
- [x] New feature

## Related Items
- Resolves #575

## Notes for reviewers
- The status item is installed in multiple places (window `awakeFromNib`, initial async dispatch, and a 0.75s retry) to guard against timing issues during app launch where the status bar item may not appear reliably on the first attempt
- Closing the main window now hides it rather than terminating the app, so users can restore it via the menu bar icon or Dock