### PR TITLE
fix[mac] :: enable app-sandbox entitlement for debug, profile, and release builds

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<false/>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -10,7 +10,9 @@
 	<true/>
 	<key>com.apple.security.device.camera</key>
 	<true/>
-	<key>com.apple.security.device.audio-input</key>
-	<true/>
-</dict>
-</plist>
+ 	<key>com.apple.security.device.audio-input</key>
+ 	<true/>
+ 	<key>com.apple.security.app-sandbox</key>
+ 	<true/>
+ </dict>
+ </plist>


### PR DESCRIPTION
## Summary

- Enabled macOS app sandbox (`com.apple.security.app-sandbox`) for both debug/profile and release builds.
- Added the sandbox entitlement to the release configuration, which previously only had network, camera, and audio-input permissions defined.

## Impact

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [x] Security

## Related Items

- Resolves #578
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers

- Enabling the app sandbox restricts the app to its own container and limits access to system resources, which is required for macOS App Store distribution. Ensure all required entitlements (network, camera, audio-input) are still functioning correctly under sandbox restrictions, as sandboxed apps must explicitly declare any resource access.