### PR TITLE
feat[mac] :: enable user-selected file read-write entitlement for debug, profile, and release builds

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -14,5 +14,7 @@
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -14,5 +14,7 @@
  	<true/>
  	<key>com.apple.security.app-sandbox</key>
  	<true/>
+ 	<key>com.apple.security.files.user-selected.read-write</key>
+ 	<true/>
  </dict>
  </plist>


### PR DESCRIPTION
## Summary

- Added `com.apple.security.files.user-selected.read-write` entitlement to both debug/profile and release macOS entitlement files to allow the sandboxed app to read and write files chosen by the user.

## Impact

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [x] Security

## Related Items

- Addresses download issue in PR #579
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers

- Without this entitlement, macOS sandboxing blocks any file read/write operations on user-selected paths, causing permission errors when attempting to save or open files through system file pickers.