### PR TITLE
fix[mac] :: strip excess entitlements and rename custom module from `browser` to `Runner`

### DIFF
--- a/macos/Runner/Base.lproj/MainMenu.xib
+++ b/macos/Runner/Base.lproj/MainMenu.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="browser" customModuleProvider="target">
+        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Runner" customModuleProvider="target">
             <connections>
                 <outlet property="applicationMenu" destination="uQy-DD-JDr" id="XBo-yE-nKs"/>
                 <outlet property="mainFlutterWindow" destination="QvC-M9-y7g" id="gIp-Ho-8D9"/>
@@ -330,7 +330,7 @@
             </items>
             <point key="canvasLocation" x="142" y="-258"/>
         </menu>
-        <window title="APP_NAME" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g" customClass="MainFlutterWindow" customModule="browser" customModuleProvider="target">
+        <window title="APP_NAME" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g" customClass="MainFlutterWindow" customModule="Runner" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <rect key="contentRect" x="335" y="390" width="800" height="600"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1577"/>

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -2,19 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.cs.allow-jit</key>
-	<true/>
-	<key>com.apple.security.network.server</key>
-	<true/>
 	<key>com.apple.security.network.client</key>
-	<true/>
-	<key>com.apple.security.device.camera</key>
-	<true/>
-	<key>com.apple.security.device.audio-input</key>
-	<true/>
-	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -2,19 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>$(AppIdentifierPrefix)$(CFBundleIdentifier)</string>
-	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
-	<key>com.apple.security.device.camera</key>
-	<true/>
- 	<key>com.apple.security.device.audio-input</key>
- 	<true/>
- 	<key>com.apple.security.app-sandbox</key>
- 	<true/>
- 	<key>com.apple.security.files.user-selected.read-write</key>
- 	<true/>
- </dict>
- </plist>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Fixed incorrect `customModule` in MainMenu.xib causing Swift module resolution failure (`browser` → `Runner`)
- Removed app-sandbox and device-related entitlements, retaining only network client access

## Context

macOS build was failing with two issues:

1. `customModule="browser"` in MainMenu.xib should be `customModule="Runner"`
2. Entitlements such as `com.apple.security.app-sandbox` require a valid development certificate to sign, breaking local and CI builds

## Changes

- **macos/Runner/Base.lproj/MainMenu.xib**: Changed `customModule="browser"` to `customModule="Runner"` for both `AppDelegate` and `MainFlutterWindow`
- **macos/Runner/DebugProfile.entitlements**: Removed `app-sandbox`, `allow-jit`, `network.server`, `device.camera`, `device.audio-input`, and `files.user-selected.read-write` entitlements, keeping only `network.client`
- **macos/Runner/Release.entitlements**: Removed `keychain-access-groups`, `app-sandbox`, `device.camera`, `device.audio-input`, and `files.user-selected.read-write` entitlements, keeping only `network.client`

## Impact

- [x] Build / CI
- [x] Bug fix

## Related Items

- Resolves #589
- Closes #591 

## Notes for reviewers

- The removed sandbox and device entitlements require an Apple Developer certificate; stripping them allows builds without one
- If camera, microphone, or file access is needed in the future, those entitlements should be re-added alongside proper certificate configuration

## Summary by CodeRabbit

- **Chores**
    - Updated macOS application module configuration
    - Removed app sandboxing, camera, microphone, file access, keychain access, and JIT compilation permissions from debug and release builds