### PR TITLE
fix[ux] :: include GitLab back fallback to handle broken history navigation from about.gitlab.com

### DIFF
--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -192,6 +192,50 @@ bool _urlsShareSite(String? firstUrl, String? secondUrl) {
   return firstKey == secondKey;
 }
 
+@visibleForTesting
+List<String> trimCurrentUrlFromHistory(List<String> history,
+    {required String currentUrl}) {
+  final normalizedCurrent = currentUrl.trim();
+  final trimmed = List<String>.from(history);
+  while (trimmed.isNotEmpty) {
+    final candidate = trimmed.last.trim();
+    if (candidate.isEmpty || candidate == normalizedCurrent) {
+      trimmed.removeLast();
+      continue;
+    }
+    break;
+  }
+  return trimmed;
+}
+
+@visibleForTesting
+bool shouldUseGitLabBackFallback({
+  required String currentUrl,
+  required List<String> history,
+}) {
+  if (history.isEmpty) return false;
+
+  final normalizedCurrent = currentUrl.trim();
+  String? previousDistinctUrl;
+
+  for (var i = history.length - 1; i >= 0; i--) {
+    final candidate = history[i].trim();
+    if (candidate.isEmpty || candidate == normalizedCurrent) continue;
+    previousDistinctUrl = candidate;
+    break;
+  }
+
+  if (previousDistinctUrl == null) return false;
+  final previousUri = Uri.tryParse(previousDistinctUrl);
+  if (previousUri == null) return false;
+
+  final isGitLabAbout = previousUri.scheme == 'https' &&
+      previousUri.host.toLowerCase() == 'about.gitlab.com';
+  if (!isGitLabAbout) return false;
+
+  return !_urlsShareSite(currentUrl, previousDistinctUrl);
+}
+
 class MediaPlaybackState {
   const MediaPlaybackState({required this.hasPlayingMedia});
 
@@ -1629,11 +1673,11 @@ class SettingsDialog extends HookWidget {
                                         ?.copyWith(fontSize: 12),
                                   ),
                                 ),
-],
-                      ),
-                      const SizedBox(height: 4),
-                      const SizedBox.shrink(),
-                    ],
+                              ],
+                            ),
+                            const SizedBox(height: 4),
+                            const SizedBox.shrink(),
+                          ],
                         ),
                         actions: [
                           TextButton(
@@ -5444,6 +5488,24 @@ class _BrowserPageState extends State<BrowserPage>
 
   Future<void> _goBack() async {
     try {
+      if (shouldUseGitLabBackFallback(
+        currentUrl: activeTab.currentUrl,
+        history: activeTab.history,
+      )) {
+        final trimmedHistory = trimCurrentUrlFromHistory(
+          activeTab.history,
+          currentUrl: activeTab.currentUrl,
+        );
+        final previousUrl =
+            trimmedHistory.reversed.map((entry) => entry.trim()).firstWhere(
+                  (entry) => entry.isNotEmpty,
+                );
+        activeTab.history
+          ..clear()
+          ..addAll(trimmedHistory);
+        await _loadUrl(previousUrl);
+        return;
+      }
       if (await activeTab.webViewController?.canGoBack() ?? false) {
         await activeTab.webViewController?.goBack();
         activeTab.forwardUrl =
@@ -5838,7 +5900,8 @@ class _BrowserPageState extends State<BrowserPage>
                 aiAvailable: widget.aiAvailable,
                 ambientToolbarEnabled: widget.ambientToolbarEnabled,
                 autoHideAddressBarEnabled: widget.autoHideAddressBarEnabled,
-                onOpenHelp: () => _loadUrl('https://bniladridas.github.io/browser/features.html'),
+                onOpenHelp: () => _loadUrl(
+                    'https://bniladridas.github.io/browser/features.html'),
               ),
             ),
           );
@@ -7312,7 +7375,8 @@ class _BrowserPageState extends State<BrowserPage>
             tab.lastAmbientProbeAt = null;
             final host = _hostFromUrl(actualUrl);
             final nextFavicon = host != null
-                ? (_faviconCacheByHost[host] ?? _defaultFaviconUrlFor(actualUrl))
+                ? (_faviconCacheByHost[host] ??
+                    _defaultFaviconUrlFor(actualUrl))
                 : _defaultFaviconUrlFor(actualUrl);
             if (nextFavicon != null && nextFavicon.isNotEmpty) {
               tab.faviconUrl = nextFavicon;

--- a/test/ux/browser_page_logic_test.dart
+++ b/test/ux/browser_page_logic_test.dart
@@ -79,6 +79,45 @@ void main() {
     });
   });
 
+  group('gitlab back fallback', () {
+    test('trims current url from history before fallback', () {
+      final trimmed = trimCurrentUrlFromHistory(
+        const [
+          'https://about.gitlab.com/',
+          'https://github.com/bniladridas/browser',
+          'https://github.com/bniladridas/browser',
+        ],
+        currentUrl: 'https://github.com/bniladridas/browser',
+      );
+
+      expect(trimmed, const ['https://about.gitlab.com/']);
+    });
+
+    test('uses manual fallback when previous distinct entry is gitlab', () {
+      final shouldFallback = shouldUseGitLabBackFallback(
+        currentUrl: 'https://github.com/bniladridas/browser',
+        history: const [
+          'https://about.gitlab.com/',
+          'https://github.com/bniladridas/browser',
+        ],
+      );
+
+      expect(shouldFallback, isTrue);
+    });
+
+    test('does not use fallback for non-gitlab previous entry', () {
+      final shouldFallback = shouldUseGitLabBackFallback(
+        currentUrl: 'https://github.com/bniladridas/browser',
+        history: const [
+          'https://www.apple.com/',
+          'https://github.com/bniladridas/browser',
+        ],
+      );
+
+      expect(shouldFallback, isFalse);
+    });
+  });
+
   group('FaviconUrlPolicy', () {
     test('parses escaped JS string favicon result', () {
       final resolved = FaviconUrlPolicy.resolveFaviconFromJsResult(


### PR DESCRIPTION
## Summary
- Add a GitLab back fallback that detects when the previous distinct history entry is `about.gitlab.com` and the current URL is on a different site, triggering a manual navigation instead of relying on the WebView's native back stack
- Introduce `trimCurrentUrlFromHistory` to strip duplicate or empty trailing entries matching the current URL before performing the fallback navigation
- Add `shouldUseGitLabBackFallback` to encapsulate the logic for determining when the fallback should be used

## Impact
- [x] Bug fix

## Related Items
- Resolves #596

## Notes for reviewers
- Both `trimCurrentUrlFromHistory` and `shouldUseGitLabBackFallback` are marked `@visibleForTesting` and covered by new unit tests. This PR addresses the immediate crash/incorrect back behavior but does not fully normalize the GitLab back-stack experience; any remaining inconsistency is consistent with Safari behavior and likely stems from underlying WebKit history handling.