### PR TITLE
feat[ux] :: include splash screen with animated transition and window resize after startup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,7 @@ import 'logging/logger.dart';
 import 'features/theme_utils.dart';
 import 'features/profile_manager.dart';
 import 'ux/browser_page.dart';
+import 'ux/splash_screen.dart';
 import 'package:pkg/ai_service.dart';
 import 'constants.dart';
 
@@ -34,10 +35,14 @@ bool _isDuplicateKeyDownAssertion(FlutterErrorDetails details) {
 
 class MyApp extends StatefulWidget {
   const MyApp(
-      {super.key, required this.aiAvailable, this.enableGitFetch = false});
+      {super.key,
+      required this.aiAvailable,
+      this.enableGitFetch = false,
+      this.splashDuration = const Duration(milliseconds: 1200)});
 
   final bool aiAvailable;
   final bool enableGitFetch;
+  final Duration splashDuration;
 
   @override
   State<MyApp> createState() => _MyAppState();
@@ -66,22 +71,72 @@ class _MyAppState extends State<MyApp> {
   bool urlAutocompleteSuggestionRemovalEnabled = false;
   bool autoHideAddressBarEnabled = false;
   bool _didCheckWhatsNew = false;
+  bool _showSplash = true;
+  bool _didScheduleWhatsNew = false;
+  bool _didRestoreWindowAfterSplash = false;
+  Timer? _splashTimer;
   final GlobalKey<NavigatorState> _navigatorKey = GlobalKey<NavigatorState>();
   @override
   void initState() {
     super.initState();
+    _showSplash = widget.splashDuration > Duration.zero;
     _loadSettings();
     _lastSettingsProfileId = profileManager.activeProfileId;
     profileManager.addListener(_handleProfileManagerChange);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _maybeShowWhatsNew();
-    });
+    if (_showSplash) {
+      _splashTimer = Timer(widget.splashDuration, _hideSplash);
+    } else {
+      unawaited(_restoreWindowAfterSplash());
+    }
   }
 
   @override
   void dispose() {
+    _splashTimer?.cancel();
     profileManager.removeListener(_handleProfileManagerChange);
     super.dispose();
+  }
+
+  void _hideSplash() {
+    if (!mounted) return;
+    setState(() {
+      _showSplash = false;
+    });
+    unawaited(_restoreWindowAfterSplash());
+  }
+
+  Future<void> _restoreWindowAfterSplash() async {
+    if (_didRestoreWindowAfterSplash ||
+        isIntegrationTest ||
+        defaultTargetPlatform != TargetPlatform.macOS) {
+      _scheduleWhatsNewCheck();
+      return;
+    }
+    _didRestoreWindowAfterSplash = true;
+    try {
+      await Future<void>.delayed(const Duration(milliseconds: 260));
+      if (!mounted) return;
+      await windowManager.setTitleBarStyle(
+        TitleBarStyle.hidden,
+        windowButtonVisibility: !hideAppBar,
+      );
+      await windowManager.setMinimumSize(const Size(820, 560));
+      await windowManager.setSize(const Size(1120, 760));
+      await windowManager.center();
+    } catch (e) {
+      logger.w('Failed to restore window size after splash: $e');
+    } finally {
+      markWindowChromeReady();
+      _scheduleWhatsNewCheck();
+    }
+  }
+
+  void _scheduleWhatsNewCheck() {
+    if (_didScheduleWhatsNew) return;
+    _didScheduleWhatsNew = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _maybeShowWhatsNew();
+    });
   }
 
   void _handleProfileManagerChange() {
@@ -329,30 +384,36 @@ class _MyAppState extends State<MyApp> {
           useAdjustedTheme: useAdjustedTheme,
         ),
         themeMode: resolvedThemeMode,
-        home: BrowserPage(
-          initialUrl: homepage,
-          hideAppBar: hideAppBar,
-          useModernUserAgent: useModernUserAgent,
-          enableGitFetch: widget.enableGitFetch || enableGitFetch,
-          aiAvailable: widget.aiAvailable,
-          privateBrowsing: privateBrowsing,
-          adBlocking: adBlocking,
-          strictMode: strictMode,
-          pageFontFamily: pageFontFamily,
-          aiSearchSuggestionsEnabled: aiSearchSuggestionsEnabled,
-          advancedCacheEnabled: advancedCacheEnabled,
-          ambientToolbarEnabled: ambientToolbarEnabled,
-          autoHideAddressBarEnabled: autoHideAddressBarEnabled,
-          urlAutocompleteSuggestionRemovalEnabled:
-              urlAutocompleteSuggestionRemovalEnabled,
-          themeMode: effectiveThemeMode,
-          onPageThemeChanged: _setAdjustedThemeMode,
-          onSettingsChanged: _loadSettings,
-          onThemePreviewChanged: _setPreviewThemeMode,
-          onThemePreviewReset: _clearPreviewThemeMode,
-          onShowWhatsNew: () async {
-            await _showWhatsNewDialog(ignoreSeenVersion: true);
-          },
+        home: AnimatedSwitcher(
+          duration: const Duration(milliseconds: 240),
+          child: _showSplash
+              ? const SplashScreen(key: ValueKey('splash'))
+              : BrowserPage(
+                  key: const ValueKey('browser'),
+                  initialUrl: homepage,
+                  hideAppBar: hideAppBar,
+                  useModernUserAgent: useModernUserAgent,
+                  enableGitFetch: widget.enableGitFetch || enableGitFetch,
+                  aiAvailable: widget.aiAvailable,
+                  privateBrowsing: privateBrowsing,
+                  adBlocking: adBlocking,
+                  strictMode: strictMode,
+                  pageFontFamily: pageFontFamily,
+                  aiSearchSuggestionsEnabled: aiSearchSuggestionsEnabled,
+                  advancedCacheEnabled: advancedCacheEnabled,
+                  ambientToolbarEnabled: ambientToolbarEnabled,
+                  autoHideAddressBarEnabled: autoHideAddressBarEnabled,
+                  urlAutocompleteSuggestionRemovalEnabled:
+                      urlAutocompleteSuggestionRemovalEnabled,
+                  themeMode: effectiveThemeMode,
+                  onPageThemeChanged: _setAdjustedThemeMode,
+                  onSettingsChanged: _loadSettings,
+                  onThemePreviewChanged: _setPreviewThemeMode,
+                  onThemePreviewReset: _clearPreviewThemeMode,
+                  onShowWhatsNew: () async {
+                    await _showWhatsNewDialog(ignoreSeenVersion: true);
+                  },
+                ),
         ),
       ),
     );
@@ -500,11 +561,13 @@ void main() async {
         try {
           await windowManager.waitUntilReadyToShow(
             const WindowOptions(
+              size: Size(640, 360),
+              center: true,
               titleBarStyle: TitleBarStyle.hidden,
-              windowButtonVisibility: true,
+              windowButtonVisibility: false,
             ),
             () {
-              markWindowChromeReady();
+              unawaited(windowManager.setOpacity(1));
               windowManager.show();
               windowManager.focus();
             },

--- a/lib/ux/splash_screen.dart
+++ b/lib/ux/splash_screen.dart
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright 2026 bniladridas. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+class SplashScreen extends StatelessWidget {
+  const SplashScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final logoSize =
+        MediaQuery.sizeOf(context).shortestSide < 420 ? 56.0 : 68.0;
+
+    return Scaffold(
+      backgroundColor: colorScheme.surface,
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 360),
+          child: Padding(
+            padding: const EdgeInsets.all(32),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(18),
+                  child: Image.asset(
+                    'assets/icons/app_icon.png',
+                    width: logoSize,
+                    height: logoSize,
+                    fit: BoxFit.cover,
+                    errorBuilder: (context, error, stackTrace) {
+                      return ColoredBox(
+                        color: colorScheme.primaryContainer,
+                        child: SizedBox.square(
+                          dimension: logoSize,
+                          child: Icon(
+                            Icons.travel_explore,
+                            color: colorScheme.onPrimaryContainer,
+                            size: logoSize * 0.54,
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'Browser',
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    fontWeight: FontWeight.w500,
+                    color: colorScheme.onSurfaceVariant.withValues(alpha: 0.82),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                SizedBox(
+                  width: 88,
+                  child: LinearProgressIndicator(
+                    minHeight: 2,
+                    borderRadius: BorderRadius.circular(999),
+                    backgroundColor: colorScheme.surfaceContainerHighest,
+                    color: colorScheme.onSurfaceVariant.withValues(alpha: 0.32),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -4,9 +4,7 @@ import FlutterMacOS
 class MainFlutterWindow: NSWindow, NSWindowDelegate {
   override func awakeFromNib() {
     let flutterViewController = FlutterViewController()
-    let windowFrame = self.frame
     self.contentViewController = flutterViewController
-    self.setFrame(windowFrame, display: true)
 
     RegisterGeneratedPlugins(registry: flutterViewController)
 
@@ -15,15 +13,35 @@ class MainFlutterWindow: NSWindow, NSWindowDelegate {
     BrowserMenuBarController.shared.install(reason: "window awakeFromNib")
     delegate = self
 
-    // Hide window initially
-    self.alphaValue = 0
+    let isIntegrationTest = ProcessInfo.processInfo.environment["INTEGRATION_TEST"] == "true"
+    guard !isIntegrationTest else {
+      self.alphaValue = 1
+      return
+    }
 
-    // Show after Flutter initializes
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-      NSAnimationContext.runAnimationGroup({ context in
-        context.duration = 0.2
-        self.animator().alphaValue = 1.0
-      }, completionHandler: nil)
+    standardWindowButton(.closeButton)?.isHidden = true
+    standardWindowButton(.miniaturizeButton)?.isHidden = true
+    standardWindowButton(.zoomButton)?.isHidden = true
+
+    let splashSize = NSSize(width: 640, height: 360)
+    if let screenFrame = screen?.visibleFrame ?? NSScreen.main?.visibleFrame {
+      let splashOrigin = NSPoint(
+        x: screenFrame.midX - splashSize.width / 2,
+        y: screenFrame.midY - splashSize.height / 2
+      )
+      setFrame(NSRect(origin: splashOrigin, size: splashSize), display: false)
+    } else {
+      setContentSize(splashSize)
+    }
+
+    minSize = splashSize
+    self.alphaValue = 0
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) { [weak self] in
+      guard let self, self.alphaValue == 0 else {
+        return
+      }
+      self.alphaValue = 1
+      self.makeKeyAndOrderFront(nil)
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -124,6 +124,7 @@ flutter:
   # see https://flutter.dev/to/font-from-package
   assets:
     - assets/ad_blockers.json
+    - assets/icons/app_icon.png
     - assets/icons/menu_bar_icon.png
     - assets/legacy_layout_fix.js
     - assets/whats_new.json

--- a/test/ux/splash_screen_test.dart
+++ b/test/ux/splash_screen_test.dart
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+//
+// Copyright 2026 bniladridas. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+import 'package:browser/ux/splash_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('SplashScreen displays startup branding',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: SplashScreen(),
+      ),
+    );
+
+    expect(find.text('Browser'), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    expect(find.byType(Image), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- Introduces a startup splash screen displaying the app logo, a branding label, and a linear progress indicator before the browser page loads.
- Starts the macOS window at a compact 640×360 splash size, then restores it to full browser dimensions after the splash completes.
- Hides native window controls (close, miniaturize, zoom) during the splash and re-applies the hidden title bar style and minimum size constraints after transition.
- Adds a Swift-side opacity fallback so the main window becomes visible if the Flutter plugin callback is delayed or fails.
- Sequences the "What's New" dialog check to fire only after the splash has been dismissed and window chrome is ready.
- Covers the splash UI with a focused widget test asserting the branding text, progress indicator, and logo image are all present.

## Impact
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Resolves #621
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers
- Review process: self-review plus focused analyzer and widget test.
- Verification: `flutter analyze --fatal-infos lib/main.dart lib/ux/splash_screen.dart test/ux/splash_screen_test.dart`
- Verification: `flutter test test/ux/splash_screen_test.dart`