### PR TITLE
chore[ux] :: remove Git fetch feature, settings toggle, and related tests

### DIFF
--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -18,15 +18,12 @@ import 'package:shared_preferences/shared_preferences.dart';
 const testTimeout = Timeout(Duration(minutes: 3));
 
 Future<void> _launchApp(WidgetTester tester,
-    {bool enableGitFetch = false,
-    bool aiSuggestionsEnabled = false,
-    bool resetPrefs = true}) async {
+    {bool aiSuggestionsEnabled = false, bool resetPrefs = true}) async {
   if (resetPrefs) {
     final prefs = await SharedPreferences.getInstance();
     await prefs.clear();
     await prefs.setBool(hideAppBarKey, false);
     await prefs.setBool(useModernUserAgentKey, false);
-    await prefs.setBool(enableGitFetchKey, enableGitFetch);
     await prefs.setBool(privateBrowsingKey, false);
     await prefs.setBool(adBlockingKey, false);
     await prefs.setBool(strictModeKey, false);
@@ -46,8 +43,7 @@ Future<void> _launchApp(WidgetTester tester,
     await profileManager.initialize();
   }
 
-  await tester
-      .pumpWidget(MyApp(aiAvailable: false, enableGitFetch: enableGitFetch));
+  await tester.pumpWidget(const MyApp(aiAvailable: false));
   await tester.pumpAndSettle();
 }
 
@@ -114,17 +110,6 @@ void main() {
     expect(tileFinder, findsOneWidget);
     final tile = tester.widget<SwitchListTile>(tileFinder);
     return tile.value;
-  }
-
-  Future<void> enableGitFetch(WidgetTester tester) async {
-    await openOverflowMenu(tester);
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Settings'));
-    await tester.pumpAndSettle();
-    await setSwitchTile(tester, title: 'Git fetch', enabled: true);
-    await tester.tap(find.text('Save'));
-    await tester.pumpAndSettle();
-    await tester.pumpAndSettle(const Duration(seconds: 2));
   }
 
   group('Browser App Tests', () {
@@ -261,33 +246,6 @@ void main() {
 
       // Should show saved snackbar
       expect(find.text('Settings saved'), findsOneWidget);
-    }, timeout: testTimeout);
-
-    testWidgets('Git fetch dialog', (WidgetTester tester) async {
-      await _launchApp(tester, enableGitFetch: true);
-
-      // First, enable Git Fetch in settings
-      await enableGitFetch(tester);
-
-      // Wait for settings to fully close
-      await Future.delayed(const Duration(milliseconds: 500));
-
-      // Now open menu and go to Git Fetch
-      await openOverflowMenu(tester);
-      await tester.pumpAndSettle();
-      expect(find.text('Git Fetch'), findsOneWidget);
-      await tester.tap(find.text('Git Fetch'));
-      await tester.pumpAndSettle();
-
-      // Should show Git Fetch dialog
-      expect(find.text('Git Fetch'), findsOneWidget);
-      expect(find.bySemanticsLabel('GitHub Repo (owner/repo)'), findsOneWidget);
-      expect(find.text('Fetch'), findsOneWidget);
-      expect(find.text('Cancel'), findsOneWidget);
-
-      await tester.tap(find.text('Cancel'));
-      await tester.pumpAndSettle();
-      expect(find.text('Git Fetch'), findsNothing);
     }, timeout: testTimeout);
 
     testWidgets('New feature toggles in settings', (WidgetTester tester) async {
@@ -501,18 +459,6 @@ void main() {
       await waitForGone(aiSuggestionsSheet);
       expect(aiSuggestionsTitle, findsNothing);
       expect(aiSuggestionsSheet, findsNothing);
-    }, timeout: testTimeout);
-
-    testWidgets('Git Fetch visibility persists after relaunch',
-        (WidgetTester tester) async {
-      await _launchApp(tester);
-      await enableGitFetch(tester);
-
-      await _launchApp(tester, resetPrefs: false);
-      await openOverflowMenu(tester);
-      await tester.pumpAndSettle();
-
-      expect(find.text('Git Fetch'), findsOneWidget);
     }, timeout: testTimeout);
 
     testWidgets('Firebase configuration can be saved in settings',

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -7,7 +7,6 @@
 const String homepageKey = 'homepage';
 const String hideAppBarKey = 'hideAppBar';
 const String useModernUserAgentKey = 'useModernUserAgent';
-const String enableGitFetchKey = 'enableGitFetch';
 const String privateBrowsingKey = 'privateBrowsing';
 const String adBlockingKey = 'adBlocking';
 const String strictModeKey = 'strictMode';

--- a/lib/features/profile_manager.dart
+++ b/lib/features/profile_manager.dart
@@ -115,7 +115,6 @@ class ProfileManager extends ChangeNotifier {
     const boolKeys = <String>[
       hideAppBarKey,
       useModernUserAgentKey,
-      enableGitFetchKey,
       privateBrowsingKey,
       adBlockingKey,
       strictModeKey,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,11 +37,9 @@ class MyApp extends StatefulWidget {
   const MyApp(
       {super.key,
       required this.aiAvailable,
-      this.enableGitFetch = false,
       this.splashDuration = const Duration(milliseconds: 1200)});
 
   final bool aiAvailable;
-  final bool enableGitFetch;
   final Duration splashDuration;
 
   @override
@@ -60,7 +58,6 @@ class _MyAppState extends State<MyApp> {
   String homepage = defaultHomepageUrl;
   bool hideAppBar = false;
   bool useModernUserAgent = false;
-  bool enableGitFetch = false;
   bool privateBrowsing = false;
   bool adBlocking = false;
   bool strictMode = false;
@@ -261,8 +258,6 @@ class _MyAppState extends State<MyApp> {
       final resolvedHideAppBar = readBool(hideAppBarKey, defaultValue: false);
       final resolvedUseModernUserAgent =
           readBool(useModernUserAgentKey, defaultValue: false);
-      final resolvedEnableGitFetch =
-          readBool(enableGitFetchKey, defaultValue: false);
       final resolvedPrivateBrowsing =
           readBool(privateBrowsingKey, defaultValue: false);
       final resolvedAdBlocking = readBool(adBlockingKey, defaultValue: false);
@@ -285,7 +280,6 @@ class _MyAppState extends State<MyApp> {
         homepage = resolvedHomepage;
         hideAppBar = resolvedHideAppBar;
         useModernUserAgent = resolvedUseModernUserAgent;
-        enableGitFetch = resolvedEnableGitFetch;
         privateBrowsing = resolvedPrivateBrowsing;
         adBlocking = resolvedAdBlocking;
         strictMode = resolvedStrictMode;
@@ -393,7 +387,6 @@ class _MyAppState extends State<MyApp> {
                   initialUrl: homepage,
                   hideAppBar: hideAppBar,
                   useModernUserAgent: useModernUserAgent,
-                  enableGitFetch: widget.enableGitFetch || enableGitFetch,
                   aiAvailable: widget.aiAvailable,
                   privateBrowsing: privateBrowsing,
                   adBlocking: adBlocking,

--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -559,7 +559,6 @@ class SettingsDialog extends HookWidget {
     final homepage = useState<String?>(null);
     final hideAppBar = useState(false);
     final useModernUserAgent = useState(false);
-    final enableGitFetch = useState(false);
     final privateBrowsing = useState(false);
     final originalPrivateBrowsing = useRef<bool?>(null);
     final adBlocking = useState(false);
@@ -813,7 +812,6 @@ class SettingsDialog extends HookWidget {
         hideAppBar.value = readBool(hideAppBarKey, defaultValue: false);
         useModernUserAgent.value =
             readBool(useModernUserAgentKey, defaultValue: false);
-        enableGitFetch.value = readBool(enableGitFetchKey, defaultValue: false);
         privateBrowsing.value =
             readBool(privateBrowsingKey, defaultValue: false);
         originalPrivateBrowsing.value = privateBrowsing.value;
@@ -1036,15 +1034,6 @@ class SettingsDialog extends HookWidget {
                       title: const Text('Legacy UA'),
                       value: useModernUserAgent.value,
                       onChanged: (value) => useModernUserAgent.value = value,
-                      hoverColor: Colors.transparent,
-                    ),
-                  ),
-                  MouseRegion(
-                    cursor: SystemMouseCursors.click,
-                    child: SwitchListTile(
-                      title: const Text('Git fetch'),
-                      value: enableGitFetch.value,
-                      onChanged: (value) => enableGitFetch.value = value,
                       hoverColor: Colors.transparent,
                     ),
                   ),
@@ -1546,8 +1535,6 @@ class SettingsDialog extends HookWidget {
             await prefs.setBool(scopedKey(hideAppBarKey), hideAppBar.value);
             await prefs.setBool(
                 scopedKey(useModernUserAgentKey), useModernUserAgent.value);
-            await prefs.setBool(
-                scopedKey(enableGitFetchKey), enableGitFetch.value);
             await prefs.setBool(
                 scopedKey(privateBrowsingKey), privateBrowsing.value);
             await prefs.setBool(scopedKey(adBlockingKey), adBlocking.value);
@@ -2080,197 +2067,12 @@ class _ThemeTone {
   const _ThemeTone({required this.brightness, this.seedColor});
 }
 
-Future<Map<String, dynamic>> _fetchGitHubRepo(String url) async {
-  final stopwatch = Stopwatch()..start();
-  try {
-    final response =
-        await http.get(Uri.parse(url)).timeout(const Duration(seconds: 10));
-    NetworkMonitor().logRequest(
-      url: url,
-      method: 'GET',
-      statusCode: response.statusCode,
-      duration: stopwatch.elapsed,
-    );
-    if (response.statusCode == 200) {
-      return jsonDecode(response.body);
-    } else {
-      throw Exception('Failed to load repo: ${response.statusCode}');
-    }
-  } catch (e) {
-    NetworkMonitor().onRequestFailed(
-      url: url,
-      method: 'GET',
-      error: e is Exception ? e : Exception(e.toString()),
-      duration: stopwatch.elapsed,
-    );
-    rethrow;
-  }
-}
-
-class GitFetchDialog extends HookWidget {
-  const GitFetchDialog({super.key, required this.onOpenInNewTab});
-
-  final void Function(String url) onOpenInNewTab;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final repoController = useTextEditingController();
-    final isLoading = useState(false);
-    final repoData = useState<Map<String, dynamic>?>(null);
-    final errorMessage = useState<String?>(null);
-    final isDisposed = useRef(false);
-
-    useEffect(() {
-      return () {
-        isDisposed.value = true;
-      };
-    }, []);
-
-    Future<void> fetchRepo() async {
-      final repo = repoController.text.trim();
-      if (repo.isEmpty) return;
-
-      final parts = repo.split('/');
-      if (parts.length != 2) {
-        if (!isDisposed.value) {
-          errorMessage.value = 'Invalid format. Use owner/repo';
-        }
-        return;
-      }
-
-      if (!isDisposed.value) {
-        isLoading.value = true;
-        errorMessage.value = null;
-        repoData.value = null;
-      }
-
-      try {
-        final url = 'https://api.github.com/repos/${parts[0]}/${parts[1]}';
-        final response = await _fetchGitHubRepo(url);
-        if (!isDisposed.value) {
-          isLoading.value = false;
-          repoData.value = response;
-        }
-      } catch (e) {
-        if (!isDisposed.value) {
-          isLoading.value = false;
-          errorMessage.value = 'Failed to fetch repo: $e';
-        }
-      }
-    }
-
-    return AlertDialog(
-      title: Text(
-        'Git Fetch',
-        style: theme.textTheme.titleSmall?.copyWith(fontSize: 15),
-      ),
-      content: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 420),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            TextField(
-              controller: repoController,
-              style: theme.textTheme.bodyMedium?.copyWith(fontSize: 13),
-              decoration: InputDecoration(
-                labelText: 'GitHub Repo (owner/repo)',
-                hintText: 'e.g., flutter/flutter',
-                isDense: true,
-                filled: false,
-                enabledBorder: UnderlineInputBorder(
-                  borderSide: BorderSide(
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
-                ),
-                focusedBorder: UnderlineInputBorder(
-                  borderSide: BorderSide(
-                    color: theme.colorScheme.primary,
-                  ),
-                ),
-              ),
-            ),
-            const SizedBox(height: 10),
-            if (isLoading.value)
-              const Padding(
-                padding: EdgeInsets.symmetric(vertical: 6),
-                child: SizedBox(
-                  width: 16,
-                  height: 16,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                ),
-              ),
-            if (errorMessage.value != null)
-              Text(
-                errorMessage.value!,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  fontSize: 12,
-                  color: theme.colorScheme.error,
-                ),
-              ),
-            if (repoData.value != null) ...[
-              const SizedBox(height: 8),
-              Text(
-                'Name: ${repoData.value!['name'] ?? 'N/A'}',
-                style: theme.textTheme.bodySmall?.copyWith(fontSize: 12),
-              ),
-              Text(
-                'Description: ${repoData.value!['description'] ?? 'No description'}',
-                style: theme.textTheme.bodySmall?.copyWith(fontSize: 12),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-              ),
-              Text(
-                'Stars: ${repoData.value!['stargazers_count'] ?? 0}',
-                style: theme.textTheme.bodySmall?.copyWith(fontSize: 12),
-              ),
-              Text(
-                'Forks: ${repoData.value!['forks_count'] ?? 0}',
-                style: theme.textTheme.bodySmall?.copyWith(fontSize: 12),
-              ),
-              Text(
-                'Language: ${repoData.value!['language'] ?? 'N/A'}',
-                style: theme.textTheme.bodySmall?.copyWith(fontSize: 12),
-              ),
-              Text(
-                'Open Issues: ${repoData.value!['open_issues_count'] ?? 0}',
-                style: theme.textTheme.bodySmall?.copyWith(fontSize: 12),
-              ),
-            ],
-          ],
-        ),
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: const Text('Cancel'),
-        ),
-        TextButton(
-          onPressed: fetchRepo,
-          child: const Text('Fetch'),
-        ),
-        if (repoData.value != null)
-          TextButton(
-            onPressed: () {
-              final url = 'https://github.com/${repoController.text}';
-              onOpenInNewTab(url);
-              Navigator.of(context).pop();
-            },
-            child: const Text('Open in New Tab'),
-          ),
-      ],
-    );
-  }
-}
-
 class BrowserPage extends StatefulWidget {
   const BrowserPage(
       {super.key,
       required this.initialUrl,
       this.hideAppBar = false,
       this.useModernUserAgent = false,
-      this.enableGitFetch = false,
       this.privateBrowsing = false,
       this.adBlocking = false,
       this.strictMode = false,
@@ -2291,7 +2093,6 @@ class BrowserPage extends StatefulWidget {
   final String initialUrl;
   final bool hideAppBar;
   final bool useModernUserAgent;
-  final bool enableGitFetch;
   final bool privateBrowsing;
   final bool adBlocking;
   final bool strictMode;
@@ -6301,9 +6102,6 @@ class _BrowserPageState extends State<BrowserPage>
       case 'page_font':
         _showFontPicker();
         break;
-      case 'git_fetch':
-        _showGitFetchDialog();
-        break;
       case 'network_debug':
         _showNetworkDebug();
         break;
@@ -6377,13 +6175,6 @@ class _BrowserPageState extends State<BrowserPage>
         icon: Icons.history,
         label: 'History',
       ),
-      if (widget.enableGitFetch)
-        _buildMenuItem(
-          context,
-          value: 'git_fetch',
-          icon: Icons.code,
-          label: 'Git Fetch',
-        ),
       if (widget.aiAvailable)
         _buildMenuItem(
           context,
@@ -6470,38 +6261,6 @@ class _BrowserPageState extends State<BrowserPage>
           ),
         );
       },
-    );
-  }
-
-  void _showGitFetchDialog() {
-    showDialog(
-      context: context,
-      builder: (context) => GitFetchDialog(
-        onOpenInNewTab: (url) {
-          final uri = Uri.tryParse(url);
-          if (uri == null) {
-            logger.w('Invalid URL: $url');
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Invalid URL')),
-            );
-            return; // Don't create a new tab for an invalid URL
-          }
-
-          _addNewTab();
-          activeTab.currentUrl = url;
-          activeTab.urlController.text = url;
-          try {
-            activeTab.webViewController?.loadRequest(uri);
-          } on PlatformException catch (e, s) {
-            if (!_isMissingPluginException(e)) {
-              logger.w(
-                  'Unexpected PlatformException on loadRequest (Git Fetch)',
-                  error: e,
-                  stackTrace: s);
-            }
-          }
-        },
-      ),
     );
   }
 

--- a/test/ux/settings_dialog_test.dart
+++ b/test/ux/settings_dialog_test.dart
@@ -80,8 +80,6 @@ void main() {
       await prefs.setBool(
           profileManager.getScopedStorageKey(useModernUserAgentKey), true);
       await prefs.setBool(
-          profileManager.getScopedStorageKey(enableGitFetchKey), true);
-      await prefs.setBool(
           profileManager.getScopedStorageKey(aiSearchSuggestionsEnabledKey),
           true);
       await prefs.setBool(
@@ -102,7 +100,6 @@ void main() {
       );
 
       expect(_readSwitchTile(tester, 'Legacy UA').value, isTrue);
-      expect(_readSwitchTile(tester, 'Git fetch').value, isTrue);
       expect(_readSwitchTile(tester, 'AI suggestions').value, isTrue);
       expect(_readSwitchTile(tester, 'Erase suggestions').value, isTrue);
       expect(_readSwitchTile(tester, 'Hide URL').value, isTrue);


### PR DESCRIPTION
## Summary

- Removes the `enableGitFetch` preference key, setting toggle, and all related stored preference handling.
- Removes the `GitFetchDialog` widget, `_fetchGitHubRepo` helper, and the Git Fetch overflow menu entry.
- Removes the `enableGitFetch` parameter from `MyApp` and `BrowserPage`.
- Updates profile migration and integration/unit tests to remove coverage of the Git Fetch flow.

## Impact

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [x] Refactor / cleanup
- [ ] Documentation
- [x] Tests
- [ ] Performance
- [ ] Security

## Related Items

- Resolves #627
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers

- Review process: self-review plus focused reference search and settings test.
- Verification: `rg -n "Git Fetch|Git fetch|enableGitFetch|enableGitFetchKey|_fetchGitHubRepo|GitFetchDialog|git_fetch" lib test integration_test`
- Verification: `flutter test test/ux/settings_dialog_test.dart`
- Note: targeted fatal-info analyze still reports existing Flutter 3.44 deprecation infos in `browser_page.dart` that are outside this change.