### PR TITLE
fix[ux] :: use LayoutBuilder for responsive vertical centering on Torry search page

### DIFF
--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -6895,121 +6895,139 @@ class _BrowserPageState extends State<BrowserPage>
           : colorScheme.surface,
       child: SafeArea(
         bottom: false,
-        child: Align(
-          alignment: Alignment.topCenter,
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.fromLTRB(18, 14, 18, 12),
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 560),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Container(
-                    padding: const EdgeInsets.all(14),
-                    decoration: BoxDecoration(
-                      color: colorScheme.primaryContainer,
-                      borderRadius: BorderRadius.circular(16),
-                    ),
-                    child: Icon(
-                      Icons.security,
-                      size: 36,
-                      color: colorScheme.onPrimaryContainer,
-                    ),
-                  ),
-                  const SizedBox(height: 10),
-                  Text(
-                    'Private search via torry.io.',
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: colorScheme.onSurfaceVariant,
-                      fontSize: 13,
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 14),
-                  Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 10),
-                    decoration: BoxDecoration(
-                      color: colorScheme.surfaceContainerHighest,
-                      borderRadius: BorderRadius.circular(14),
-                      border: Border.all(
-                        color: colorScheme.outline.withValues(alpha: 0.45),
-                      ),
-                    ),
-                    child: TextField(
-                      controller: tab.torrySearchController,
-                      focusNode: tab.torrySearchFocusNode,
-                      textInputAction: TextInputAction.search,
-                      textAlignVertical: TextAlignVertical.center,
-                      style: theme.textTheme.bodyMedium?.copyWith(fontSize: 13),
-                      onSubmitted: (s) => _performTorrySearch(tab, s),
-                      decoration: InputDecoration(
-                        hintText: 'Search',
-                        isDense: true,
-                        border: InputBorder.none,
-                        contentPadding:
-                            const EdgeInsets.symmetric(vertical: 10),
-                        prefixIcon: Icon(
-                          Icons.search,
-                          color: colorScheme.primary,
-                          size: 18,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            const horizontalPadding = 18.0;
+            const verticalPadding = 28.0;
+            final topBreathingRoom =
+                (constraints.maxHeight * 0.18).clamp(72.0, 220.0);
+
+            return SingleChildScrollView(
+              padding: EdgeInsets.fromLTRB(
+                horizontalPadding,
+                topBreathingRoom,
+                horizontalPadding,
+                verticalPadding,
+              ),
+              child: Align(
+                alignment: Alignment.topCenter,
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 560),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.all(14),
+                        decoration: BoxDecoration(
+                          color: colorScheme.primaryContainer,
+                          borderRadius: BorderRadius.circular(16),
                         ),
-                        prefixIconConstraints:
-                            const BoxConstraints(minHeight: 36, minWidth: 42),
-                        suffixIcon: MouseRegion(
-                          cursor: SystemMouseCursors.click,
-                          child: GestureDetector(
-                            onTap: () => _performTorrySearch(tab),
-                            child: Padding(
-                              padding: const EdgeInsets.all(8),
-                              child: Icon(
-                                Icons.arrow_forward,
-                                color: colorScheme.primary,
-                                size: 22,
+                        child: Icon(
+                          Icons.security,
+                          size: 36,
+                          color: colorScheme.onPrimaryContainer,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        'Private search via torry.io.',
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                          fontSize: 13,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 18),
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 10),
+                        decoration: BoxDecoration(
+                          color: colorScheme.surfaceContainerHighest,
+                          borderRadius: BorderRadius.circular(14),
+                          border: Border.all(
+                            color: colorScheme.outline.withValues(alpha: 0.45),
+                          ),
+                        ),
+                        child: TextField(
+                          controller: tab.torrySearchController,
+                          focusNode: tab.torrySearchFocusNode,
+                          textInputAction: TextInputAction.search,
+                          textAlignVertical: TextAlignVertical.center,
+                          style: theme.textTheme.bodyMedium
+                              ?.copyWith(fontSize: 13),
+                          onSubmitted: (s) => _performTorrySearch(tab, s),
+                          decoration: InputDecoration(
+                            hintText: 'Search',
+                            isDense: true,
+                            border: InputBorder.none,
+                            contentPadding:
+                                const EdgeInsets.symmetric(vertical: 10),
+                            prefixIcon: Icon(
+                              Icons.search,
+                              color: colorScheme.primary,
+                              size: 18,
+                            ),
+                            prefixIconConstraints: const BoxConstraints(
+                              minHeight: 36,
+                              minWidth: 42,
+                            ),
+                            suffixIcon: MouseRegion(
+                              cursor: SystemMouseCursors.click,
+                              child: GestureDetector(
+                                onTap: () => _performTorrySearch(tab),
+                                child: Padding(
+                                  padding: const EdgeInsets.all(8),
+                                  child: Icon(
+                                    Icons.arrow_forward,
+                                    color: colorScheme.primary,
+                                    size: 22,
+                                  ),
+                                ),
                               ),
                             ),
                           ),
                         ),
                       ),
-                    ),
-                  ),
-                  const SizedBox(height: 10),
-                  Wrap(
-                    spacing: 8,
-                    runSpacing: 6,
-                    alignment: WrapAlignment.center,
-                    children: [
-                      TextButton.icon(
-                        onPressed: () =>
-                            _loadUrl('https://www.torry.io/learn/directory/'),
-                        icon: const Icon(Icons.list),
-                        label: const Text(
-                          'Onion directory',
-                          style: TextStyle(fontSize: 12),
-                        ),
-                        style: TextButton.styleFrom(
-                          visualDensity: VisualDensity.compact,
-                        ),
-                      ),
-                      TextButton.icon(
-                        onPressed: () =>
-                            _loadUrl('https://www.torry.io/anonymous-view/'),
-                        icon: const Icon(Icons.visibility),
-                        label: const Text(
-                          'Anonymous view',
-                          style: TextStyle(fontSize: 12),
-                        ),
-                        style: TextButton.styleFrom(
-                          visualDensity: VisualDensity.compact,
-                        ),
+                      const SizedBox(height: 14),
+                      Wrap(
+                        spacing: 10,
+                        runSpacing: 8,
+                        alignment: WrapAlignment.center,
+                        children: [
+                          TextButton.icon(
+                            onPressed: () => _loadUrl(
+                              'https://www.torry.io/learn/directory/',
+                            ),
+                            icon: const Icon(Icons.list),
+                            label: const Text(
+                              'Onion directory',
+                              style: TextStyle(fontSize: 12),
+                            ),
+                            style: TextButton.styleFrom(
+                              visualDensity: VisualDensity.compact,
+                            ),
+                          ),
+                          TextButton.icon(
+                            onPressed: () => _loadUrl(
+                              'https://www.torry.io/anonymous-view/',
+                            ),
+                            icon: const Icon(Icons.visibility),
+                            label: const Text(
+                              'Anonymous view',
+                              style: TextStyle(fontSize: 12),
+                            ),
+                            style: TextButton.styleFrom(
+                              visualDensity: VisualDensity.compact,
+                            ),
+                          ),
+                        ],
                       ),
                     ],
                   ),
-                  const SizedBox(height: 8),
-                ],
+                ),
               ),
-            ),
-          ),
+            );
+          },
         ),
       ),
     );


### PR DESCRIPTION
## Summary

- Replaces the fixed `Align`/`SingleChildScrollView` wrapper on the Torry search home surface with a `LayoutBuilder` that computes a responsive top padding clamped between 72 and 220 logical pixels at 18 % of the available height.
- Moves `Align` inside the scroll view so the constrained content stays centered as the viewport grows.
- Slightly relaxes vertical spacing between the icon, subtitle, search field, and shortcut buttons, and increases `Wrap` spacing from 8/6 to 10/8.

## Impact

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items

- Resolves #636
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers

- Review process: self-review plus focused diff and whitespace checks.
- Verification: `dart format lib/ux/browser_page.dart`
- Verification: `git diff --check`
- Note: `flutter analyze lib/ux/browser_page.dart` still reports the existing Flutter 3.44 deprecation infos for `SizeTransition.axisAlignment` and `ReorderableListView.onReorder`; those are outside this chunk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined the search home view layout to improve responsiveness and dynamic spacing across different screen sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bniladridas/browser/pull/637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->