### PR TITLE
feat[ci] :: migrate all workflows to GitHub App token authentication

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,5 +1,5 @@
----
 # SPDX-License-Identifier: MIT
+---
 #
 # Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
@@ -18,8 +18,21 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'bniladridas'
     permissions:
-      pull-requests: write
-      issues: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
+
+      - id: app-token
+        name: Create Browser app token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.BROWSER_APP_ID }}
+          private-key: ${{ secrets.BROWSER_APP_PRIVATE_KEY }}
+          permission-issues: write
+          permission-pull-requests: write
+          permission-contents: read
+
       - uses: libnudget/auto-label@v1
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: MIT
+---
+#
+# Copyright 2026 bniladridas. All rights reserved.
+# Use of this source code is governed by a MIT license that can be
+# found in the LICENSE file.
+
+name: Browser
+
+on:
+  push:
+    branches: [main]
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  check:
+    name: Browser
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'bniladridas'
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - id: app-token
+        name: Create Browser app token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.BROWSER_APP_ID }}
+          private-key: ${{ secrets.BROWSER_APP_PRIVATE_KEY }}
+          permission-checks: write
+          permission-pull-requests: read
+          permission-contents: read
+
+      - name: Publish check
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          gh api "repos/$REPO/check-runs" \
+            -X POST \
+            -f name='Browser' \
+            -f head_sha="$HEAD_SHA" \
+            -f status='completed' \
+            -f conclusion='success' \
+            -f 'output[title]=Browser automation' \
+            -f 'output[summary]=Browser app automation is active for this ref.' \
+            --silent

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: MIT
+---
 #
 # Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 
----
 name: CLA
 
 on:
@@ -37,7 +37,17 @@ jobs:
           cp signed.json cla-signers.json
           cp signed.json cla-bot/cla-signers.json
 
+      - id: app-token
+        name: Create Browser app token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.BROWSER_APP_ID }}
+          private-key: ${{ secrets.BROWSER_APP_PRIVATE_KEY }}
+          permission-issues: write
+          permission-pull-requests: write
+          permission-contents: read
+
       - name: Run CLA bot
         uses: ./cla-bot/
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,5 +1,5 @@
----
 # SPDX-License-Identifier: MIT
+---
 #
 # Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
@@ -13,12 +13,24 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: write
-  issues: write
+  contents: read
 
 jobs:
   close-stale-issues:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'bniladridas'
     steps:
+      - id: app-token
+        name: Create Browser app token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.BROWSER_APP_ID }}
+          private-key: ${{ secrets.BROWSER_APP_PRIVATE_KEY }}
+          permission-actions: write
+          permission-issues: write
+          permission-contents: read
+
       - uses: libnudget/stale@v1
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -35,9 +35,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - id: app-token
+        name: Create Browser app token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.BROWSER_APP_ID }}
+          private-key: ${{ secrets.BROWSER_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+          permission-contents: read
+
       - name: Create PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           head="${{ inputs.head }}"

--- a/.github/workflows/issue-similarity.yml
+++ b/.github/workflows/issue-similarity.yml
@@ -1,5 +1,5 @@
----
 # SPDX-License-Identifier: MIT
+---
 #
 # Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
@@ -17,11 +17,19 @@ jobs:
     if: github.repository_owner == 'bniladridas'
     permissions:
       contents: read
-      issues: write
     steps:
+      - id: app-token
+        name: Create Browser app token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.BROWSER_APP_ID }}
+          private-key: ${{ secrets.BROWSER_APP_PRIVATE_KEY }}
+          permission-issues: write
+          permission-contents: read
+
       - uses: libnudget/echo@main
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           repository: ${{ github.repository }}
           issue_number: ${{ github.event.issue.number }}
           issue_title: ${{ github.event.issue.title }}

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,5 +1,5 @@
----
 # SPDX-License-Identifier: MIT
+---
 #
 # Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
@@ -20,13 +20,23 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'bniladridas'
     permissions:
-      issues: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
+
+      - id: app-token
+        name: Create Browser app token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.BROWSER_APP_ID }}
+          private-key: ${{ secrets.BROWSER_APP_PRIVATE_KEY }}
+          permission-issues: write
+          permission-contents: read
+
       - name: Sync repository labels
         uses: crazy-max/ghaction-github-labeler@v5
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           yaml-file: .github/labels.yml
           dry-run: false
           skip-delete: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,5 @@
----
 # SPDX-License-Identifier: MIT
+---
 #
 # Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
@@ -24,6 +24,8 @@ jobs:
       app-name: 'browser'
       base-branch: 'main'
     secrets:
+      github-app-id: ${{ secrets.BROWSER_APP_ID }}
+      github-app-private-key: ${{ secrets.BROWSER_APP_PRIVATE_KEY }}
       macos-code-sign-identity: ${{ secrets.MACOS_CODE_SIGN_IDENTITY }}
       macos-certificate: ${{ secrets.MACOS_CERTIFICATE }}
       macos-certificate-password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
----
 # SPDX-License-Identifier: MIT
+---
 #
 # Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
@@ -18,7 +18,7 @@ on:
         required: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-and-release:
@@ -28,11 +28,21 @@ jobs:
       MACOS_CODE_SIGN_IDENTITY: ${{ secrets.MACOS_CODE_SIGN_IDENTITY }}
 
     steps:
+      - id: app-token
+        name: Create Browser app token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.BROWSER_APP_ID }}
+          private-key: ${{ secrets.BROWSER_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag || github.ref }}
           fetch-tags: true
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-flutter
         with:
@@ -153,6 +163,7 @@ jobs:
           files: build/macos/Build/Products/Release/browser.dmg
           generate_release_notes: false
           tag_name: ${{ steps.validate-tag.outputs.tag }}
+          token: ${{ steps.app-token.outputs.token }}
         continue-on-error: true
 
       - name: Verify upload

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,5 +1,5 @@
----
 # SPDX-License-Identifier: MIT
+---
 #
 # Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
@@ -23,13 +23,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - id: app-token
+        name: Create Browser app token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.BROWSER_APP_ID }}
+          private-key: ${{ secrets.BROWSER_APP_PRIVATE_KEY }}
+          permission-actions: write
+          permission-contents: write
+          permission-pull-requests: write
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - uses: libnudget/bump@main
         with:
           pr-number: ${{ github.event.pull_request.number }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/signed.json
+++ b/signed.json
@@ -1,6 +1,7 @@
 {
   "signed": [
     "bniladridas",
+    "browser-dart[bot]",
     "github-actions[bot]"
   ]
 }


### PR DESCRIPTION
## Summary

- Route supported repository automations through Browser GitHub App tokens with scoped permissions.
- Introduce a Browser check workflow that publishes an app-backed check run for pushes and pull requests.
- Pass Browser app credentials into nightly, release, version bump, CLA, labeling, stale issue, issue similarity, and PR creation workflows where writes are required.
- Keep user-owned project board automation outside this change because it still needs its existing PAT.
- Include `browser-dart[bot]` in `signed.json` so Browser app automation can satisfy CLA checks.

## Impact

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [x] Security

## Related Items

- Resolves #642
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers

- Review process used: self-review and automated workflow linting.
- Verified with yamllint on changed workflows, actionlint on changed workflows, jq for `signed.json`, and `git diff --check`.
- Requires `BROWSER_APP_ID` and `BROWSER_APP_PRIVATE_KEY` repository secrets to be configured before merging.