### PR TITLE
fix[ci] :: remove persist-credentials: false from version-bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -38,7 +38,6 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
 
       - uses: libnudget/bump@main
         with:


### PR DESCRIPTION
## Summary

- Removed `persist-credentials: false` from the version bump workflow checkout step.
- Restores git push authentication so the workflow can push the version bump branch using the app token.

## Impact

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items

- Resolves #644
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers

- Previously, `persist-credentials: false` was preventing the workflow from authenticating when pushing the version bump branch after `libnudget/bump` ran.
- Credentials are now retained so the app token obtained earlier in the workflow is available for the subsequent git push.