### PR TITLE
chore[ci] :: bump auto-label action from v1 to v2

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -32,7 +32,7 @@ jobs:
           permission-pull-requests: write
           permission-contents: read
 
-      - uses: libnudget/auto-label@v1
+      - uses: libnudget/auto-label@v2
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Upgrade the auto-label workflow to use `libnudget/auto-label@v2`.
- Retain the existing app token wiring for pull request and issue label permissions.

## Impact

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items

- Resolves #647
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers

- Review process: self-review and yamllint on `.github/workflows/auto-label.yml`.
- The version bump picks up any fixes or improvements shipped in `libnudget/auto-label` v2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal GitHub Actions workflow configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bniladridas/browser/pull/648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->