### PR TITLE
chore[ci] :: bump Flutter to 3.44.0, fix Firebase placeholders, and move SPDX headers before YAML markers

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -1,5 +1,5 @@
----
 # SPDX-License-Identifier: MIT
+---
 #
 # Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be

--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -1,5 +1,5 @@
----
 # SPDX-License-Identifier: MIT
+---
 #
 # Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
@@ -12,7 +12,7 @@ inputs:
   flutter-version:
     description: 'Flutter version to install'
     required: true
-    default: '3.41.5'
+    default: '3.44.0'
 
 runs:
   using: 'composite'

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,20 @@
+# GitHub Workflows
+
+Workflow files in this directory use a shared layout:
+
+- SPDX license header first.
+- YAML document marker (`---`) second.
+- Short workflow name and focused job names.
+- Repository-owner guards for automation that should only run in this repository.
+- Browser GitHub App tokens for automation that writes to pull requests, issues, projects, or refs.
+
+Workflow groups:
+
+- `flutter.yml`, `ui-test.yml`, and `e2e.yml` run the main Flutter checks.
+- `lint.yml` and `pr-title-check.yml` keep repository formatting and PR metadata consistent.
+- `auto-label.yml`, `label-sync.yml`, `close-stale-issues.yml`, `issue-similarity.yml`, and
+  `project-board-sync.yml` handle issue and pull request automation.
+- `nightly.yml`, `release.yml`, and `version-bump.yml` handle release automation.
+- `browser.yml`, `cla.yml`, and `create-pr.yml` support repository-specific automation.
+
+Use `yamllint .github/workflows` after changing workflow files.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,16 +22,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-flutter
         with:
-          flutter-version: '3.41.7'
+          flutter-version: '3.44.0'
       - run: flutter pub get
       - name: Generate code
         run: flutter pub run build_runner build --delete-conflicting-outputs
       - name: Create .env file
         run: |
           {
-            echo "FIREBASE_API_KEY=dummy_api_key"
-            echo "FIREBASE_APP_ID=dummy_app_id"
-            echo "FIREBASE_MESSAGING_SENDER_ID=dummy_sender_id"
+            echo "FIREBASE_API_KEY=AIzaSy000000000000000000000000000000000"
+            echo "FIREBASE_APP_ID=1:1234567890:ios:0123456789abcdef012345"
+            echo "FIREBASE_MESSAGING_SENDER_ID=1234567890"
             echo "FIREBASE_PROJECT_ID=dummy_project_id"
             echo "FIREBASE_STORAGE_BUCKET=dummy_storage_bucket"
           } > .env
@@ -43,7 +43,7 @@ jobs:
           <plist version="1.0">
           <dict>
               <key>API_KEY</key>
-              <string>dummy_api_key</string>
+              <string>AIzaSy000000000000000000000000000000000</string>
               <key>BUNDLE_ID</key>
               <string>com.bniladridas.browser</string>
               <key>GCM_SENDER_ID</key>

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -22,14 +22,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-flutter
         with:
-          flutter-version: '3.41.7'
+          flutter-version: '3.44.0'
       - run: flutter pub get
       - name: Create .env file
         run: |
           {
-            echo "FIREBASE_API_KEY=dummy_api_key"
-            echo "FIREBASE_APP_ID=dummy_app_id"
-            echo "FIREBASE_MESSAGING_SENDER_ID=dummy_sender_id"
+            echo "FIREBASE_API_KEY=AIzaSy000000000000000000000000000000000"
+            echo "FIREBASE_APP_ID=1:1234567890:ios:0123456789abcdef012345"
+            echo "FIREBASE_MESSAGING_SENDER_ID=1234567890"
             echo "FIREBASE_PROJECT_ID=dummy_project_id"
             echo "FIREBASE_STORAGE_BUCKET=dummy_storage_bucket"
             } > .env
@@ -45,13 +45,13 @@ jobs:
             <key>REVERSED_CLIENT_ID</key>
             <string>com.google.ReverseClientId</string>
             <key>API_KEY</key>
-            <string>dummy</string>
+            <string>AIzaSy000000000000000000000000000000000</string>
             <key>GCM_SENDER_ID</key>
             <string>123456789</string>
             <key>PLIST_VERSION</key>
             <string>1</string>
             <key>BUNDLE_ID</key>
-            <string>com.example.browser</string>
+            <string>com.bniladridas.browser</string>
             <key>PROJECT_ID</key>
             <string>dummy-project</string>
             <key>STORAGE_BUCKET</key>
@@ -67,7 +67,7 @@ jobs:
             <key>IS_SIGNIN_ENABLED</key>
             <true/>
             <key>GOOGLE_APP_ID</key>
-            <string>1:123456789:ios:abcdef</string>
+            <string>1:1234567890:ios:0123456789abcdef012345</string>
           </dict>
           </plist>
           EOF

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
   nightly:
     uses: libnudget/nightly/.github/workflows/nightly.yml@main
     with:
-      flutter-version: '3.41.7'
+      flutter-version: '3.44.0'
       tag-prefix: 'desktop/nightly-'
       app-name: 'browser'
       base-branch: 'main'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,15 +46,15 @@ jobs:
 
       - uses: ./.github/actions/setup-flutter
         with:
-          flutter-version: '3.41.7'
+          flutter-version: '3.44.0'
 
       - run: flutter pub get
       - name: Create .env file
         run: |
           {
-            echo "FIREBASE_API_KEY=dummy_api_key"
-            echo "FIREBASE_APP_ID=dummy_app_id"
-            echo "FIREBASE_MESSAGING_SENDER_ID=dummy_sender_id"
+            echo "FIREBASE_API_KEY=AIzaSy000000000000000000000000000000000"
+            echo "FIREBASE_APP_ID=1:1234567890:ios:0123456789abcdef012345"
+            echo "FIREBASE_MESSAGING_SENDER_ID=1234567890"
             echo "FIREBASE_PROJECT_ID=dummy_project_id"
             echo "FIREBASE_STORAGE_BUCKET=dummy_bucket"
           } > .env
@@ -69,10 +69,10 @@ jobs:
           <dict>
             <key>CLIENT_ID</key><string>dummy</string>
             <key>REVERSED_CLIENT_ID</key><string>com.google.ReverseClientId</string>
-            <key>API_KEY</key><string>dummy</string>
+            <key>API_KEY</key><string>AIzaSy000000000000000000000000000000000</string>
             <key>GCM_SENDER_ID</key><string>123456789</string>
             <key>PLIST_VERSION</key><string>1</string>
-            <key>BUNDLE_ID</key><string>com.example.browser</string>
+            <key>BUNDLE_ID</key><string>com.bniladridas.browser</string>
             <key>PROJECT_ID</key><string>dummy-project</string>
             <key>STORAGE_BUCKET</key><string>dummy-project.appspot.com</string>
             <key>IS_ADS_ENABLED</key><false/>
@@ -80,7 +80,7 @@ jobs:
             <key>IS_APPINVITE_ENABLED</key><true/>
             <key>IS_GCM_ENABLED</key><true/>
             <key>IS_SIGNIN_ENABLED</key><true/>
-            <key>GOOGLE_APP_ID</key><string>1:123456789:ios:abcdef</string>
+            <key>GOOGLE_APP_ID</key><string>1:1234567890:ios:0123456789abcdef012345</string>
           </dict>
           </plist>
           EOF

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -22,14 +22,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-flutter
         with:
-          flutter-version: '3.41.7'
+          flutter-version: '3.44.0'
       - run: flutter pub get
       - name: Create .env file
         run: |
           {
-            echo "FIREBASE_API_KEY=dummy_api_key"
-            echo "FIREBASE_APP_ID=dummy_app_id"
-            echo "FIREBASE_MESSAGING_SENDER_ID=dummy_sender_id"
+            echo "FIREBASE_API_KEY=AIzaSy000000000000000000000000000000000"
+            echo "FIREBASE_APP_ID=1:1234567890:ios:0123456789abcdef012345"
+            echo "FIREBASE_MESSAGING_SENDER_ID=1234567890"
             echo "FIREBASE_PROJECT_ID=dummy_project_id"
             echo "FIREBASE_STORAGE_BUCKET=dummy_storage_bucket"
           } > .env
@@ -45,13 +45,13 @@ jobs:
             <key>REVERSED_CLIENT_ID</key>
             <string>dummy_reversed_client_id</string>
             <key>API_KEY</key>
-            <string>dummy_api_key</string>
+            <string>AIzaSy000000000000000000000000000000000</string>
             <key>GCM_SENDER_ID</key>
-            <string>dummy_sender_id</string>
+            <string>1234567890</string>
             <key>PLIST_VERSION</key>
             <string>1</string>
             <key>BUNDLE_ID</key>
-            <string>com.example.browser</string>
+            <string>com.bniladridas.browser</string>
             <key>PROJECT_ID</key>
             <string>dummy_project_id</string>
             <key>STORAGE_BUCKET</key>

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
----
 # SPDX-License-Identifier: MIT
+---
 #
 # Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,5 @@
----
 # SPDX-License-Identifier: MIT
+---
 #
 # Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
----
 # SPDX-License-Identifier: MIT
+---
 #
 # Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be


### PR DESCRIPTION
## Summary

- Align GitHub workflow Flutter setup calls with Flutter 3.44.0.
- Refresh CI Firebase placeholder values and bundle identifiers used by macOS workflow checks.
- Document workflow groups and YAML header conventions.
- Normalize YAML header order in shared config files.

## Impact

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Build / CI
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items

- Resolves #650
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers

- All workflows (`flutter.yml`, `ui-test.yml`, `e2e.yml`, `release.yml`, `nightly.yml`) and the `setup-flutter` action now pin Flutter to `3.44.0`.
- Firebase placeholder values have been updated to structurally valid formats (e.g. `AIzaSy000000000000000000000000000000000`, `1:1234567890:ios:0123456789abcdef012345`) and bundle IDs corrected from `com.example.browser` to `com.bniladridas.browser`.
- A new `README.md` under `.github/workflows` describes workflow groupings and the expected YAML header convention (SPDX comment before the `---` document marker).
- The SPDX comment / `---` ordering fix applies to `pubspec.yaml`, `analysis_options.yaml`, `.pre-commit-config.yaml`, and the shared actions; run `yamllint` after reviewing to confirm no regressions.