### PR TITLE
fix[ci] :: remove persist-credentials: false from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,6 @@ jobs:
           ref: ${{ github.event.inputs.tag || github.ref }}
           fetch-tags: true
           token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
 
       - uses: ./.github/actions/setup-flutter
         with:


### PR DESCRIPTION
## Summary

- Removed `persist-credentials: false` from the release workflow checkout step to ensure the app token credentials are retained and available during the release process.

## Impact

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items

- Resolves #653
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers

- This change allows the checkout action to persist the app token credentials, which may be required for authenticated git operations later in the release workflow.