### PR TITLE
fix[ux] :: suppress deprecated member warnings and exclude build dir from analysis

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,6 +16,10 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  exclude:
+    - build/**
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: MIT
+---
 #
 # Copyright 2026 bniladridas. All rights reserved.
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 
----
 description: This file stores settings for Dart & Flutter DevTools.
 documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
 extensions:

--- a/lib/ux/browser_page.dart
+++ b/lib/ux/browser_page.dart
@@ -7948,6 +7948,7 @@ class _BrowserPageState extends State<BrowserPage>
                                 child: SizeTransition(
                                   sizeFactor: animation,
                                   axis: Axis.horizontal,
+                                  // ignore: deprecated_member_use
                                   axisAlignment: -1.0,
                                   child: child,
                                 ),
@@ -8157,6 +8158,7 @@ class _BrowserPageState extends State<BrowserPage>
                         ? ReorderableListView.builder(
                             scrollDirection: Axis.horizontal,
                             itemCount: tabs.length,
+                            // ignore: deprecated_member_use
                             onReorder: _reorderTab,
                             onReorderStart: (_) {
                               _setWindowMovable(false);


### PR DESCRIPTION
## Summary

- Exclude the `build/` directory from Dart analyzer scans to avoid false positives on generated output.
- Move the YAML document start marker (`---`) to the top of `devtools_options.yaml`, placing it before the copyright comment block.
- Add targeted `// ignore: deprecated_member_use` suppressions around `axisAlignment` in `SizeTransition` and `onReorder` in `ReorderableListView.builder` to silence deprecation warnings without broadening suppression scope.

## Impact

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items

- Resolves #656
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers

- The `deprecated_member_use` ignores are intentionally kept as narrow inline suppressions rather than global lint rule disables, so any new usages of deprecated APIs elsewhere will still be caught.
- The analyzer exclusion only affects static analysis; the `build/` directory remains part of the compiled output.
- Verify `devtools_options.yaml` is still parsed correctly after the `---` marker reorder with a YAML lint pass.