### PR TITLE
fix[ci] :: include persist-credentials: false to release workflow checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
           ref: ${{ github.event.inputs.tag || github.ref }}
           fetch-tags: true
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-flutter
         with:


### PR DESCRIPTION
## Summary

- Restore the release workflow checkout credential opt-out.

## Impact

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [x] Security

## Related Items

- Resolves #659
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers

- Review process: self-review, yamllint on release.yml, and git diff whitespace check.
- Follow-up to PR #654 after inline review noted the persisted write token was unnecessary for release build steps.