### PR TITLE
fix[ci/scripts] :: include Release job name and fix app bundle casing to Browser.app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ permissions:
 
 jobs:
   build-and-release:
+    name: Release
     runs-on: macos-latest
     if: github.repository_owner == 'bniladridas'
     env:

--- a/scripts/macos_release_dmg.sh
+++ b/scripts/macos_release_dmg.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-APP_PATH="${APP_PATH:-build/macos/Build/Products/Release/browser.app}"
+APP_PATH="${APP_PATH:-build/macos/Build/Products/Release/Browser.app}"
 DMG_PATH="${DMG_PATH:-build/macos/Build/Products/Release/browser.dmg}"
 VOLUME_NAME="${VOLUME_NAME:-browser}"
 TMP_ROOT="${TMP_ROOT:-}"

--- a/scripts/macos_unquarantine.sh
+++ b/scripts/macos_unquarantine.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-APP_PATH="${1:-/Applications/browser.app}"
+APP_PATH="${1:-/Applications/Browser.app}"
 
 if [[ ! -d "${APP_PATH}" ]]; then
   echo "App bundle not found: ${APP_PATH}" >&2


### PR DESCRIPTION
## Summary
- Updated the macOS DMG helper default app path to match the built Browser.app bundle.
- Updated the macOS unquarantine helper default path to match the installed Browser.app bundle.
- Set the release job display name to match the existing Release workflow naming style.

## Impact
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items
- Resolves #668
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers
- Follow-up to PR #666 after the macOS product name changed to Browser.
- Verification: bash -n scripts/macos_release_dmg.sh; bash -n scripts/macos_unquarantine.sh; yamllint .github/workflows/release.yml
- Review process: self-review and focused local checks.