### PR TITLE
chore[ci] :: bump Flutter to 3.41.9 and fix SPDX header ordering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: MIT
+---
 #
-# Copyright 2026 bniladridas.
-# Use of this source code is governed by a MIT license
+# Copyright 2026 bniladridas. All rights reserved.
+# Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 
----
 version: 2.1
 
 executors:
   flutter:
     docker:
-      - image: ghcr.io/cirruslabs/flutter:3.41.2
+      - image: ghcr.io/cirruslabs/flutter:3.41.9
     working_directory: ~/project
 
 commands:


### PR DESCRIPTION
## Summary

- Updated CircleCI to use the available `ghcr.io/cirruslabs/flutter:3.41.9` image.
- Normalized the CircleCI YAML header with the repository workflow style by moving the `---` document start marker to the top.
- Updated the copyright notice to include "All rights reserved." and expanded the license line for clarity.

## Impact

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items

- Resolves #675
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers

- Review process: self-review plus YAML parse validation.
- Verification: `python3 -c 'import yaml; yaml.safe_load(open(".circleci/config.yml")); print("circleci yaml ok")'`
- Note: `ghcr.io/cirruslabs/flutter:3.41.2` was replaced with `3.41.9` as the newer patch version available in the registry.