### PR TITLE
chore[docs] :: normalize tone, casing, and wording across README and codex files

### DIFF
--- a/.codex/CHECKLISTS.md
+++ b/.codex/CHECKLISTS.md
@@ -17,11 +17,11 @@
 - Bump `VERSION` to `X.Y.Z+N`.
 - Run `./scripts/pubspec.sh`.
 - Commit with `chore: bump version to X.Y.Z`.
-- Tag release `desktop/app-X.Y.Z`.
-- Title release `Release X.Y.Z`.
+- Use the release workflow or app automation for `desktop/app-X.Y.Z`.
+- Title releases `Release X.Y.Z`.
 
 ## PR Quality Gate
 
 - Validate `## Impact` before PR create/edit.
 - Ensure every checked Impact box is backed by at least one `## Summary` bullet.
-- Use GitHub auto-link keywords only (`Resolves #...`, `Closes #...`).
+- Use GitHub auto-link keywords (`Resolves #...`, `Closes #...`).

--- a/.codex/CONTRIBUTING.md
+++ b/.codex/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Use this file to capture how Codex should operate within this repository.
 
 - Keep changes small and directly tied to the request.
 - Follow PR title format: `type[scope] :: description`.
-- Follow commit format: `type(scope): description` or `type[scope]: description`.
+- Follow commit format: `type: description`.
 - Do not bypass hooks or skip required checks.
 - Avoid editing generated files unless explicitly requested.
 

--- a/.codex/NOTES.md
+++ b/.codex/NOTES.md
@@ -13,26 +13,22 @@ Keep entries short and dated when useful.
 
 - Prefer small, focused PRs with clear titles and summaries.
 - Follow PR title format: `type[scope] :: description`.
-- Follow commit format: `type(scope): description` or `type[scope]: description`.
+- Follow commit format: `type: description`.
 - Do not bypass hooks (no `--no-verify`).
 - Keep docs concise and action-oriented.
 
-## Search Suggestions
-
-- When a search or keystroke yields no results, show a nearest-match hint so users know what to try next.
-
 ## Command Guidance
 
-- Prefer `apply_patch` for file edits, especially when patching is the only change; `exec_command` caused the warning that prompted this update.
+- Prefer `apply_patch` for manual file edits.
 
 ## Do / Don't
 
-Do:
+Use:
 - Use `rg` for fast searches.
 - Keep changes scoped to the request.
-- Add brief, helpful comments only when logic is non-obvious.
+- Keep comments brief and useful.
 
-Don't:
+Avoid:
 - Revert unrelated local changes.
 - Use destructive git commands unless explicitly requested.
 - Add Codex-only guidance outside `.codex/` unless asked.

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,9 +1,13 @@
-# Codex Workspace
+# Codex workspace
 
-This directory stores Codex-specific notes, docs, and helper assets for this repository.
+This directory keeps repo-local notes for Codex-assisted work.
 
 ## Contents
 
 - `README.md`: What this folder is and how to use it.
 - `NOTES.md`: Project context, conventions, and decision logs.
 - `WORKFLOWS.md`: Repeatable tasks and checklists for Codex-assisted work.
+- `CHECKLISTS.md`: Short review and delivery checklists.
+- `CONTRIBUTING.md`: Local contribution guidance.
+- `TEMPLATES.md`: PR and review templates.
+- `skill.md`: Shorthand and typo normalization guidance.

--- a/.codex/TEMPLATES.md
+++ b/.codex/TEMPLATES.md
@@ -25,10 +25,10 @@ Examples:
 - [ ] Performance
 - [ ] Security
 
-Impact validation rule (required):
+Impact validation rule:
 - Before PR create/edit, verify each checked category has at least one matching Summary bullet.
 - If no concrete change supports a category, keep it unchecked.
-- Never skip this validation step.
+- Keep this validation step in place.
 
 ## Related Items
 - Resolves #[issue-number]
@@ -39,4 +39,4 @@ Impact validation rule (required):
 - Additional details or context
 
 ## Review
-Reviewed using Graphite Agent
+Reviewed using self-review or automated review.

--- a/.codex/WORKFLOWS.md
+++ b/.codex/WORKFLOWS.md
@@ -23,17 +23,17 @@ Use this file for repeatable Codex-assisted tasks and checklists.
   - `gh pr create`
   - `gh pr merge`
 
-## PR Impact Validation (Required)
+## PR Impact Validation
 
 - Before running `gh pr create` or `gh pr edit`, review `## Impact`.
 - Check only categories directly supported by `## Summary` bullets.
 - If a box cannot be justified from `## Summary`, uncheck it.
 - Re-run this validation after any PR description update.
 
-## Version Bump (Manual)
+## Version Bump
 
 - Update `VERSION` to `X.Y.Z+N`.
 - Run `./scripts/pubspec.sh`.
 - Commit with `chore: bump version to X.Y.Z`.
-- Create PR titled `chore: bump version to X.Y.Z`.
-- Tag release `desktop/app-X.Y.Z` and title `Release X.Y.Z`.
+- Create a PR titled `chore[version] :: bump version to X.Y.Z`.
+- Use release automation for `desktop/app-X.Y.Z` when the release is ready.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,21 +87,21 @@ Follow the repository's pre-commit hooks for commit messages:
 - Use conventional commit format without scope punctuation: `type: description`
 - Keep the first line lowercase
 - Keep the first line concise (max 40 characters) to satisfy hook checks
-- NEVER use the word "add" in commit messages - Use alternative verbs like "integrate", "implement", "include", "attach", "configure", "setup", "enable", "support", etc.
+- Do not use the word "add" in commit messages. Use alternatives like "integrate", "implement", "include", "attach", "configure", "setup", "enable", or "support".
 - Examples:
-  - `feat: add crashlytics integration` (NOT ALLOWED)
-  - `feat: integrate crashlytics for crash reporting` (USE THIS INSTEAD)
-  - `fix: add button alignment fix` (NOT ALLOWED)
-  - `fix: resolve button alignment issue` (USE THIS INSTEAD)
+  - `feat: add crashlytics integration` (avoid)
+  - `feat: integrate crashlytics for crash reporting` (use)
+  - `fix: add button alignment fix` (avoid)
+  - `fix: resolve button alignment issue` (use)
 
 Validation Rule: Before committing, verify the commit message does not contain the word "add" (case-insensitive). Use:
 ```bash
-git log --oneline -1 | grep -qiw "add" && echo "ERROR: Commit message contains 'add'" || echo "OK"
+git log --oneline -1 | grep -qiw "add" && echo "commit message contains 'add'" || echo "ok"
 ```
 
 Note: For robust handling of user input (e.g., PR titles), use `printf "%s\n" "$VAR" | grep -qiw "add"` instead of `echo "$VAR" | grep -qiw "add"` to avoid issues with input starting with hyphens.
 
-Agents must adhere to these rules to pass CI checks. Do not use --no-verify or bypass hooks; fix issues to ensure code quality.
+Agents should follow these rules to pass CI checks. Do not use --no-verify or bypass hooks; fix issues instead.
 
 ## Issue Tracking During PR Work
 
@@ -263,7 +263,7 @@ git status
 git diff --stat
 git add assets/whats_new.json pubspec.yaml
 git commit -m "chore: finalize X.Y.Z bump"
-git log --oneline -1 | grep -qiw "add" && echo "ERROR: Commit message contains 'add'" || echo "OK"
+git log --oneline -1 | grep -qiw "add" && echo "commit message contains 'add'" || echo "ok"
 git push
 
 # PR metadata updates
@@ -305,7 +305,7 @@ This project uses Firebase with environment variables. For local development:
    - Run `flutterfire configure --platforms=macos` to generate real config
    - Or create a dummy file at `macos/Runner/GoogleService-Info.plist`
 
-**Warning**: If `.env` is not provided with correct Firebase variables, the macOS app will crash with:
+Note: if `.env` is not provided with correct Firebase variables, the macOS app can crash with:
 ```text
 Exception Type: EXC_CRASH (SIGABRT)
 Application Specific Information: abort() called
@@ -323,7 +323,7 @@ read -p "Enter your PR title: " PR_TITLE
 
 # Validate PR title does not contain "add"
 if printf "%s\n" "$PR_TITLE" | grep -qiw "add"; then
-  echo "ERROR: PR title contains 'add'. Use alternative verbs like integrate, implement, include, etc."
+  echo "PR title contains 'add'. Use alternatives like integrate, implement, or include."
   exit 1
 fi
 
@@ -357,36 +357,36 @@ gh pr create \
 ## Verification Steps
 
 > [!NOTE]
-> **Test word boundary matching**
+> **word boundary check**
 > ```bash
-> # Should match (contains standalone "add")
-> printf "%s\n" "fix: add address handling" | grep -qiw "add" && echo "FOUND" || echo "NOT FOUND"
+> # matches standalone "add"
+> printf "%s\n" "fix: add address handling" | grep -qiw "add" && echo "found" || echo "not found"
 >
-> # Should NOT match (no standalone "add")
-> printf "%s\n" "fix: integrate address handling" | grep -qiw "add" && echo "FOUND" || echo "NOT FOUND"
+> # does not match when there is no standalone "add"
+> printf "%s\n" "fix: integrate address handling" | grep -qiw "add" && echo "found" || echo "not found"
 >
-> # Should NOT match (contains "padding" not "add")
-> printf "%s\n" "fix: padding issue" | grep -qiw "add" && echo "FOUND" || echo "NOT FOUND"
+> # does not match words like "padding"
+> printf "%s\n" "fix: padding issue" | grep -qiw "add" && echo "found" || echo "not found"
 > ```
 
-> [!WARNING]
-> **Verify commit message validation**
+> [!NOTE]
+> **commit message check**
 > ```bash
-> # Test with prohibited word
-> printf "%s\n" "feat: add crashlytics integration" | grep -qiw "add" && echo "ERROR: Contains 'add'" || echo "OK"
+> # contains the prohibited word
+> printf "%s\n" "feat: add crashlytics integration" | grep -qiw "add" && echo "contains 'add'" || echo "ok"
 >
-> # Test with allowed alternative
-> printf "%s\n" "feat: integrate crashlytics for crash reporting" | grep -qiw "add" && echo "ERROR: Contains 'add'" || echo "OK"
+> # allowed alternative
+> printf "%s\n" "feat: integrate crashlytics for crash reporting" | grep -qiw "add" && echo "contains 'add'" || echo "ok"
 > ```
 
 > [!TIP]
-> **Verify PR title format**
+> **PR title format**
 > ```bash
-> # This PR title (valid)
+> # valid title
 > printf "%s\n" "chore[guidelines] :: integrate commit message and pr title validation" | grep -E "^(feat|fix|docs|refactor|chore|deps|perf|ci|build|revert)\[[a-zA-Z0-9]+\]\ ::\ .+" && echo "Format valid" || echo "Format invalid"
 >
-> # This would be invalid (contains "add")
-> printf "%s\n" "chore[guidelines] :: add validation for pr titles" | grep -qiw "add" && echo "Contains prohibited word" || echo "OK"
+> # contains the prohibited word
+> printf "%s\n" "chore[guidelines] :: add validation for pr titles" | grep -qiw "add" && echo "contains prohibited word" || echo "ok"
 > ```
 EOF
 )"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-| **`CI`** | **`Flutter`** |
+| `lint` | `flutter` |
 |:--------- |:------------ |
 | [![Lint](https://github.com/bniladridas/browser/actions/workflows/lint.yml/badge.svg)](https://github.com/bniladridas/browser/actions/workflows/lint.yml) | [![Flutter](https://github.com/bniladridas/browser/actions/workflows/flutter.yml/badge.svg)](https://github.com/bniladridas/browser/actions/workflows/flutter.yml) |
 
@@ -6,7 +6,7 @@
 
 ![Screenshot](assets/screenshot.png)
 
-Flutter desktop web browser with tabs, bookmarks, history, and encrypted settings storage. One codebase covers macOS, Windows, Linux, and platform-specific Firebase integrations.
+Flutter desktop browser with tabs, bookmarks, history, and encrypted settings storage. The app runs on macOS, Windows, and Linux.
 
 ## Quick start
 
@@ -26,63 +26,70 @@ Do not commit `.env`; it contains private Firebase keys.
 
 ## Firebase configuration
 
-All Firebase values live in `.env`. The app expects the variables at runtime so the generated `lib/firebase_options.dart` remains under version control and references `const String` placeholders.
+Firebase values are read from `.env` at runtime. The generated `lib/firebase_options.dart` stays under version control and references `const String` placeholders.
 
 <details>
-<summary>To regenerate platform files after changing Firebase config</summary>
+<summary>regenerate platform files after changing Firebase config</summary>
 
 1. Update `.env` with the new Firebase project credentials.
 2. Run `flutterfire configure --platforms macos` to refresh the generated files.
-3. Immediately run `git checkout -- lib/firebase_options.dart` to revert the generated file back to the version that references environment variables.
+3. Run `git checkout -- lib/firebase_options.dart` to keep the environment-variable version.
 4. Restart `flutter run` to pick up the new settings.
 
-macOS additionally requires `macos/Runner/GoogleService-Info.plist`; `flutterfire configure` creates it automatically, or copy it from your Firebase console. Confirm the plist lives next to the generated macOS runner, and keep `.env.example` as a template for local copies so you can safely generate new `.env` files with valid credentials.
+macOS also needs `macos/Runner/GoogleService-Info.plist`. `flutterfire configure` creates it, or you can copy it from the Firebase console. Keep `.env.example` as a template for local `.env` files.
 
 </details>
 
 ## Development
 
-- Requires Flutter >=3.0.0 and the desktop toolchains for the target platforms.
+- Requires Flutter 3.44.0 and the desktop toolchains for the target platforms.
 - Run `./check.sh` to apply formatting, lint, and build checks shared across platforms.
 - Build the signed macOS app with `flutter build macos` and adjust profiles with Xcode if needed.
 - If you hit missing Firebase credentials while targeting macOS, double-check that `.env` is populated before launching the app.
 
+## Release automation
+
+[Release 1.28.9](https://github.com/bniladridas/browser/releases/tag/desktop/app-1.28.9) was the last desktop release published directly by GitHub Actions.
+Current workflow automation uses the [browser-dart](https://github.com/apps/browser-dart) GitHub App where elevated repository access is needed, including release and project automation.
+
 ## Keyboard shortcuts
 
-Keys are defined in `lib/utils/keyboard_utils.dart` with platform-neutral aliases.
+Keys are defined in `lib/utils/keyboard_utils.dart`.
 
-| Key | Action |
-| --- | ------ |
-| `[` / `LogicalKeyboardKey.bracketLeft` | Move to the previous tab |
-| `]` / `LogicalKeyboardKey.bracketRight` | Advance to the next tab |
-| `Left Arrow` / `LogicalKeyboardKey.arrowLeft` | Navigate backwards in history |
-| `Right Arrow` / `LogicalKeyboardKey.arrowRight` | Navigate forwards in history |
-| `R` / `LogicalKeyboardKey.keyR` | Reload the current tab |
-| `T` / `LogicalKeyboardKey.keyT` | Open a new tab |
-| `Escape` / `LogicalKeyboardKey.escape` | Close dialogs or stop loading |
-| `Tab` / `LogicalKeyboardKey.tab` | Focus the address bar or tool strip |
-
-Modifier keys include `Meta` (Cmd on macOS), `Control`, `Alt`, and `Shift`.
+| macOS | Windows/Linux | Action |
+| --- | --- | --- |
+| `Cmd + [` | `Alt + Left` | Navigate backwards in history |
+| `Cmd + ]` | `Alt + Right` | Navigate forwards in history |
+| `Cmd + R` | `Ctrl + R` | Reload the current tab |
+| `Cmd + T` | `Ctrl + T` | Open a new tab |
+| `Cmd + W` | `Ctrl + W` | Close the current tab |
+| `Cmd + F` | `Ctrl + F` | Focus the address bar |
+| `Cmd + Shift + F` | `Ctrl + Shift + F` | Open the page font picker |
+| `Cmd + Option + Left` | `Ctrl + Shift + Tab` | Move to the previous tab |
+| `Cmd + Option + Right` | `Ctrl + Tab` | Move to the next tab |
+| `Cmd + Enter` | `F11` | Toggle fullscreen |
+| `Cmd + M` | `Meta + Down` | Minimize the window |
+| `Escape` | `Escape` | Close dialogs or stop loading |
 
 ## macOS unsigned installs (no paid Developer ID)
 
-Unsigned builds trigger Gatekeeper warnings. The first launch steps keep the workflow entirely within the Finder UI:
+Unsigned builds can show Gatekeeper warnings. The first launch can stay in Finder:
 
-1. Drag `browser.app` to **Applications**.
-2. Right-click `browser.app`, choose **Open**, and confirm the dialog.
-3. Alternatively, open **System Settings → Privacy & Security** and click **Open Anyway** for `browser.app`.
+1. Drag `Browser.app` to **Applications**.
+2. Right-click `Browser.app`, choose **Open**, and confirm the dialog.
+3. Alternatively, open **System Settings → Privacy & Security** and click **Open Anyway** for `Browser.app`.
 
-For automation, bypass Gatekeeper for the binary with:
+For Terminal installs, clear the quarantine flag with:
 
 ```bash
-xattr -rd com.apple.quarantine /Applications/browser.app
+xattr -rd com.apple.quarantine /Applications/Browser.app
 ```
 
 Only run the command if you trust the build source.
 
 ## Need help?
 
-- `docs/` contains tutorials, architecture notes, and troubleshooting guides.
+- `docs/` contains focused project notes.
 - `.codex/README.md` documents toolchains, skills, and local workflows.
 - Report bugs or feature requests via [GitHub Issues](https://github.com/bniladridas/browser/issues).
 
@@ -98,7 +105,7 @@ When a specific file should be shown in diffs, add `-linguist-generated` to `.gi
 
 ## Contribute
 
-Fork, create a branch, run the checks, then open a pull request with a descriptive conventional commit-style summary. Follow repository tooling (`./check.sh`, GitHub Actions) before submitting.
+Fork, create a branch, run the checks, then open a pull request with a short conventional commit-style summary.
 
 ## License
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,25 +1,26 @@
-# Development Setup
+# development
 
-This directory contains tools and configurations for development.
+Small notes for local development.
 
 ## Setup
 
-1. Install Flutter: https://flutter.dev/docs/get-started/install
+1. Install Flutter 3.44.0: https://docs.flutter.dev/get-started/install
 2. Clone the repo
 3. Run `./check.sh` for the full suite (codegen, analyze, unit test, macOS build, workflow lint)
 4. Use the scripts listed below when you need a smaller scope
 
 ## Scripts
 
-- `scripts/version.sh`: Bump version
-- `scripts/pubspec.sh`: Update pubspec
-- `scripts/e2e.sh`: Run e2e tests
-- `scripts/test.sh`: Run unit tests
+- `scripts/version.sh`: bump version
+- `scripts/pubspec.sh`: sync pubspec version
+- `scripts/e2e.sh`: run e2e tests
+- `scripts/test.sh`: run unit tests
 
 ## Workflows
 
-- `flutter.yml`: CI for build and tests
-- `e2e.yml`: E2E tests
-- `auto-label.yml`: Auto-label PRs
-- `lint.yml`: Lint YAML files
-- `version-bump.yml`: Version bumping
+- `flutter.yml`: Flutter build and test checks
+- `ui-test.yml`: focused UI checks
+- `e2e.yml`: macOS e2e checks
+- `lint.yml`: workflow linting
+- `version-bump.yml`: version bump automation
+- `browser.yml`, `auto-label.yml`, and `project-board-sync.yml`: app-backed repository automation

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -5,22 +5,19 @@
 # Use of this source code is governed by a MIT license that can be
 # found in the LICENSE file.
 
-# Development setup script
+# Local development setup helper.
 
-echo "Setting up development environment..."
+echo "setting up development environment..."
 
-# Check if Flutter is installed
 if ! command -v flutter &> /dev/null; then
-    echo "Flutter not found. Please install Flutter: https://flutter.dev/docs/get-started/install"
+    echo "flutter not found. install Flutter 3.44.0: https://docs.flutter.dev/get-started/install"
     exit 1
 fi
 
-echo "Flutter version: $(flutter --version)"
+echo "flutter version: $(flutter --version)"
 
-# Install dependencies
 flutter pub get
 
-# Run tests
 flutter test
 
-echo "Setup complete! Run './scripts/e2e.sh' for e2e tests."
+echo "setup complete. run './scripts/e2e.sh' for e2e tests."

--- a/docs/torry.md
+++ b/docs/torry.md
@@ -1,13 +1,13 @@
-# Torry-powered home
+# Torry home
 
 ## Overview
-- The default `about:browser-home` tab now renders a Torry-branded home screen with a contextual headline, feature chips, and quick actions instead of the previous generic branding panel.
-- A dedicated Torry search input targets `https://www.torry.io/search/?q=…` and reuses the browser tab via `_performTorrySearch`, keeping the user inside the browser while surfacing Torry results.
+- The default `about:browser-home` tab renders a quiet Torry search view instead of a generic browser panel.
+- A dedicated Torry search input targets `https://www.torry.io/search/?q=…` and reuses the current tab through `_performTorrySearch`.
 
 ## Experience
 - The search field auto-focuses when empty and submits through `_performTorrySearch`, which encodes the query and delegates to `_loadUrl`.
-- Quick-action buttons launch Torry’s search landing page, onion directory, and anonymous-view section so the home view double-checks major Torry flows.
-- The search input, buttons, and feature chips use the app’s color scheme and responsive layout to feel cohesive on desktops.
+- Quick actions open Torry’s onion directory and anonymous-view flow.
+- The search input and actions use the app color scheme and responsive layout.
 
 ## Maintenance
 - Torry search state is tracked per tab via `TabData.torrySearchController` and `TabData.torrySearchFocusNode`, and both are disposed when tabs are removed or the page is disposed to avoid leaks.

--- a/docs/xcode-setup.md
+++ b/docs/xcode-setup.md
@@ -1,8 +1,8 @@
-# Xcode Setup
+# Xcode setup
 
-## Accepting Xcode License
+## Accept Xcode license
 
-After installing Xcode, you must accept the license agreement:
+After installing Xcode, accept the license agreement:
 
 ```bash
 sudo xcodebuild -license
@@ -10,9 +10,9 @@ sudo xcodebuild -license
 
 Scroll to the bottom and type `agree` to accept.
 
-## Switching to Xcode (if using Command Line Tools)
+## Switch to Xcode
 
-If you have both Xcode and Command Line Tools installed, you may need to switch:
+If both Xcode and Command Line Tools are installed, switch to Xcode:
 
 ```bash
 sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer


### PR DESCRIPTION
## Summary

- Refreshed README wording for setup, release automation, keyboard shortcuts, and macOS unsigned install steps.
- Quieted and aligned agent guidance in `AGENTS.md`, `.codex/`, `docs/`, and `dev/` notes.
- Simplified commit format guidance to `type: description` across `CONTRIBUTING.md`, `NOTES.md`, and `AGENTS.md`.
- Updated `dev/setup.sh` prose and `dev/README.md` workflow list while keeping behavior unchanged.
- Replaced `[!WARNING]` callouts with `[!NOTE]` and lowercased shell output strings in `AGENTS.md`.

## Impact

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Build / CI
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items

- Resolves #678
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers

- Review process: self-review plus stale wording scan.
- Verification: `bash -n dev/setup.sh`
- Verification: `rg -n "browser\.app|/Applications/browser|NEVER|ERROR: |NOT FOUND|Manual\b" README.md AGENTS.md .codex dev docs || true`
- Remaining matches are expected examples or intentional references.