### PR TITLE
ci[pr-title-check] :: allow slashes and hyphens in scope pattern

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -21,7 +21,9 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if [[ ! "$TITLE" =~ ^(feat|fix|docs|refactor|chore|deps|perf|ci|build|revert)\[[a-zA-Z0-9]+\]\ ::\ .+ ]]; then
+          title_pattern='^(feat|fix|docs|refactor|chore|deps|perf|ci|build|revert)'
+          title_pattern+='\[[a-zA-Z0-9]+([/_-][a-zA-Z0-9]+)*\]\ ::\ .+'
+          if [[ ! "$TITLE" =~ $title_pattern ]]; then
             echo "PR title does not match format: type[scope] :: description"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- Expanded the PR title scope regex to allow slash (`/`), underscore (`_`), and hyphen (`-`) characters in addition to alphanumeric characters.
- Enables scopes like `feat[android/ux]`, `fix[my-module]`, or `chore[some_task]` to pass validation.

## Impact

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Build / CI
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests
- [ ] Performance
- [ ] Security

## Related Items

- Resolves #688
- Resources: [PRs tab](../../pulls), [Issues tab](../../issues)

## Notes for reviewers

- The only change is the character class in the scope portion of the regex, from `[a-zA-Z0-9]` to `[a-zA-Z0-9/_-]`. All other title format rules remain unchanged.